### PR TITLE
fix(notion): nested lists not rendering from SOW templates

### DIFF
--- a/src/shared/services/notion/lib/blocks-to-tiptap-json.ts
+++ b/src/shared/services/notion/lib/blocks-to-tiptap-json.ts
@@ -17,6 +17,7 @@ interface NotionBlock {
   id: string
   type: string
   has_children: boolean
+  children?: NotionBlock[]
   [key: string]: any // holds e.g. block.paragraph, block.heading_2, etc
 }
 
@@ -93,6 +94,22 @@ function runHandlers(handlers: BlockHandler[], block: NotionBlock): BlockHandler
   return { kind: 'skip' }
 }
 
+/** ---------- Nested list helper ---------- */
+
+/**
+ * Converts child blocks (from a list item with has_children) into a nested
+ * TipTap list node (bulletList or orderedList). Processes children through
+ * the same notionBlocksToTiptapDoc pipeline, then extracts the list node.
+ */
+function childrenToNestedList(children: NotionBlock[]): TiptapNode | null {
+  const childDoc = notionBlocksToTiptapDoc(children)
+  // The child doc will contain list nodes — return the first one found
+  const nestedList = childDoc.content?.find(
+    n => n.type === 'bulletList' || n.type === 'orderedList',
+  )
+  return nestedList ?? null
+}
+
 /** ---------- Block handlers ---------- */
 
 function handleDivider(block: NotionBlock): BlockHandlerResult {
@@ -130,14 +147,22 @@ function handleBulletedListItem(block: NotionBlock): BlockHandlerResult {
     return { kind: 'skip' }
   const rt: NotionRichText[] = block.bulleted_list_item?.rich_text ?? []
 
+  const itemContent: TiptapNode[] = [
+    {
+      type: 'paragraph',
+      content: notionRichTextToTiptap(rt),
+    },
+  ]
+
+  if (block.children?.length) {
+    const nested = childrenToNestedList(block.children)
+    if (nested)
+      itemContent.push(nested)
+  }
+
   const item: TiptapNode = {
     type: 'listItem',
-    content: [
-      {
-        type: 'paragraph',
-        content: notionRichTextToTiptap(rt),
-      },
-    ],
+    content: itemContent,
   }
 
   return { kind: 'listItem', listType: 'bulletList', item }
@@ -148,14 +173,22 @@ function handleNumberedListItem(block: NotionBlock): BlockHandlerResult {
     return { kind: 'skip' }
   const rt: NotionRichText[] = block.numbered_list_item?.rich_text ?? []
 
+  const itemContent: TiptapNode[] = [
+    {
+      type: 'paragraph',
+      content: notionRichTextToTiptap(rt),
+    },
+  ]
+
+  if (block.children?.length) {
+    const nested = childrenToNestedList(block.children)
+    if (nested)
+      itemContent.push(nested)
+  }
+
   const item: TiptapNode = {
     type: 'listItem',
-    content: [
-      {
-        type: 'paragraph',
-        content: notionRichTextToTiptap(rt),
-      },
-    ],
+    content: itemContent,
   }
 
   return { kind: 'listItem', listType: 'orderedList', item }

--- a/src/shared/services/notion/lib/page-to-tiptap-json.ts
+++ b/src/shared/services/notion/lib/page-to-tiptap-json.ts
@@ -2,13 +2,36 @@ import type { NotionBlock } from '@notion-utils/html'
 import { notionClient } from '../client'
 import { notionBlocksToTiptapDoc } from './blocks-to-tiptap-json'
 
+/**
+ * Recursively fetch children for blocks that have nested content
+ * (e.g. nested list items inside a bulleted_list_item).
+ */
+async function resolveChildren(blocks: NotionBlock[]): Promise<NotionBlock[]> {
+  return Promise.all(
+    blocks.map(async (block) => {
+      if (!block.has_children)
+        return block
+
+      const childResponse = await notionClient.blocks.children.list({
+        block_id: block.id,
+        page_size: 100,
+      }) as { results: NotionBlock[] }
+
+      const children = await resolveChildren(childResponse.results)
+
+      return { ...block, children }
+    }),
+  )
+}
+
 export async function pageToTiptapJson(pageId: string) {
   const response = await notionClient.blocks.children.list({
     block_id: pageId,
     page_size: 100,
   }) as { results: NotionBlock[] }
 
-  const tiptapJson = notionBlocksToTiptapDoc(response.results)
+  const blocks = await resolveChildren(response.results)
+  const tiptapJson = notionBlocksToTiptapDoc(blocks)
 
   return JSON.stringify(tiptapJson)
 }


### PR DESCRIPTION
## Summary
- Recursively fetch child blocks from Notion API for blocks with `has_children: true`
- Convert nested children into proper TipTap sub-list nodes (`bulletList`/`orderedList` inside `listItem`)
- Fixes SOW templates importing with only top-level list items — all nested content was silently dropped

## Changes
- `src/shared/services/notion/lib/page-to-tiptap-json.ts` — added `resolveChildren()` to recursively fetch nested blocks before conversion
- `src/shared/services/notion/lib/blocks-to-tiptap-json.ts` — added `children?` to `NotionBlock` interface, `childrenToNestedList()` helper, updated `handleBulletedListItem` and `handleNumberedListItem` to render nested sub-lists

## Self-Review
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Diff reviewed — 1 commit, 2 files, scoped to the fix

## Test Plan
- [x] Verified locally: SOW templates with nested lists now render all levels
- [ ] Import a SOW template with 2+ nesting levels in the proposal flow
- [ ] Confirm top-level + child + grandchild items all populate

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)