### PR TITLE
feat(proposals): optional expiration datetime for incentives

### DIFF
--- a/src/features/proposal-flow/ui/components/expiration-badge.tsx
+++ b/src/features/proposal-flow/ui/components/expiration-badge.tsx
@@ -1,0 +1,19 @@
+import { format } from 'date-fns'
+import { ClockIcon } from 'lucide-react'
+
+interface Props {
+  expiresAt: Date
+}
+
+export function ExpirationBadge({ expiresAt }: Props) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+      <ClockIcon className="h-3 w-3 shrink-0" />
+      <span>
+        Eligible to be claimed until
+        {' '}
+        {format(expiresAt, 'MMMM d, yyyy \'at\' h:mm a')}
+      </span>
+    </div>
+  )
+}

--- a/src/features/proposal-flow/ui/components/form/funding-fields.tsx
+++ b/src/features/proposal-flow/ui/components/form/funding-fields.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react'
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form'
 import { formValuesToProposal } from '@/features/proposal-flow/lib/converters'
 import { getProposalAggregates } from '@/features/proposal-flow/lib/get-proposal-aggregates'
+import { DateTimePicker } from '@/shared/components/date-time-picker'
 import { Button } from '@/shared/components/ui/button'
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/shared/components/ui/form'
 import { Input } from '@/shared/components/ui/input'
@@ -253,6 +254,23 @@ export function FundingFields({
 
                           </FormControl>
                           <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      name={`funding.data.incentives.${index}.expiresAt`}
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormItem className="self-end">
+                          <FormControl>
+                            <DateTimePicker
+                              placeholder="Set expiration"
+                              value={field.value ? new Date(field.value) : undefined}
+                              onChange={(date) => {
+                                field.onChange(date ? date.toISOString() : undefined)
+                              }}
+                            />
+                          </FormControl>
                         </FormItem>
                       )}
                     />

--- a/src/features/proposal-flow/ui/components/pricing-breakdown.tsx
+++ b/src/features/proposal-flow/ui/components/pricing-breakdown.tsx
@@ -2,6 +2,7 @@ import type { InsertProposalSchema } from '@/shared/db/schema'
 import { CheckIcon } from 'lucide-react'
 import { formatAsDollars } from '@/shared/lib/formatters'
 import { cn } from '@/shared/lib/utils'
+import { ExpirationBadge } from './expiration-badge'
 
 export function PricingBreakdown({ proposalData }: { proposalData: InsertProposalSchema }) {
   const { pricingMode } = proposalData.formMetaJSON
@@ -48,33 +49,46 @@ export function PricingBreakdown({ proposalData }: { proposalData: InsertProposa
           <div className="border-t border-border/40" />
           <div className="px-5 py-4 space-y-2.5 text-emerald-700 dark:text-emerald-400">
             {incentives.map((incentive, i) => {
+              const isExpired = incentive.expiresAt ? new Date() >= new Date(incentive.expiresAt) : false
+              const expiresAt = incentive.expiresAt ? new Date(incentive.expiresAt) : null
+
               if (incentive.type === 'discount') {
                 return (
-                  <div key={`discount-${incentive.notes ?? i}`} className="flex items-center justify-between">
-                    <span>{incentive.notes || 'Discount'}</span>
-                    <span className="font-medium">
-                      -
-                      {formatAsDollars(incentive.amount)}
-                    </span>
+                  <div key={`discount-${incentive.notes ?? i}`} className="space-y-1">
+                    <div className={cn('flex items-center justify-between', isExpired && 'line-through opacity-60')}>
+                      <span>{incentive.notes || 'Discount'}</span>
+                      <span className="font-medium">
+                        -
+                        {formatAsDollars(incentive.amount)}
+                      </span>
+                    </div>
+                    {expiresAt && !isExpired && (
+                      <ExpirationBadge expiresAt={expiresAt} />
+                    )}
                   </div>
                 )
               }
               return (
-                <div key={`offer-${incentive.offer ?? i}`} className="flex items-center justify-between">
-                  <div className="flex items-center">
-                    <span className="">{incentive.offer || 'Exclusive Offer'}</span>
-                    {incentive.notes && (
-                      <span className="mx-2 flex items-center gap-2">
-                        {' '}
-                        -
-                        <p className="text-muted-foreground text-xs">{incentive.notes}</p>
-                      </span>
-                    )}
+                <div key={`offer-${incentive.offer ?? i}`} className="space-y-1">
+                  <div className={cn('flex items-center justify-between', isExpired && 'line-through opacity-60')}>
+                    <div className="flex items-center">
+                      <span>{incentive.offer || 'Exclusive Offer'}</span>
+                      {incentive.notes && (
+                        <span className="mx-2 flex items-center gap-2">
+                          {' '}
+                          -
+                          <p className="text-muted-foreground text-xs">{incentive.notes}</p>
+                        </span>
+                      )}
+                    </div>
+                    <span className="font-medium flex items-center gap-1">
+                      <CheckIcon className="w-3.5 h-3.5" />
+                      Included
+                    </span>
                   </div>
-                  <span className="font-medium flex items-center gap-1">
-                    <CheckIcon className="w-3.5 h-3.5" />
-                    Included
-                  </span>
+                  {expiresAt && !isExpired && (
+                    <ExpirationBadge expiresAt={expiresAt} />
+                  )}
                 </div>
               )
             })}

--- a/src/shared/entities/proposals/schemas.ts
+++ b/src/shared/entities/proposals/schemas.ts
@@ -20,12 +20,14 @@ const discountIncentiveSchema = z.object({
   type: z.literal('discount'),
   amount: z.number(),
   notes: z.string().optional(),
+  expiresAt: z.iso.datetime().optional(),
 })
 
 const exclusiveOfferIncentiveSchema = z.object({
   type: z.literal('exclusive-offer'),
   offer: z.string(),
   notes: z.string().optional(),
+  expiresAt: z.iso.datetime().optional(),
 })
 
 const incentiveSchema = z.discriminatedUnion('type', [discountIncentiveSchema, exclusiveOfferIncentiveSchema])


### PR DESCRIPTION
## Summary
- Adds optional `expiresAt` datetime field to discount and exclusive-offer incentive schemas (JSONB, no migration needed)
- Adds DateTimePicker to the proposal edit form for each incentive row
- Public pricing breakdown shows urgency badge ("Eligible to be claimed until...") when active, or strikethrough when expired

## Changes
- `src/shared/entities/proposals/schemas.ts` — `expiresAt: z.iso.datetime().optional()` on both incentive schemas
- `src/features/proposal-flow/ui/components/form/funding-fields.tsx` — DateTimePicker before TrashIcon
- `src/features/proposal-flow/ui/components/pricing-breakdown.tsx` — conditional expired/active rendering
- `src/features/proposal-flow/ui/components/expiration-badge.tsx` — new component (amber clock + formatted date)

## Self-Review
- [x] `pnpm lint` — passes (only pre-existing warnings)
- [x] `pnpm build` — compiles and type-checks clean
- [x] Backward compatible — `expiresAt` is optional, existing incentives unaffected

## Test Plan
- [ ] Add a discount incentive, set an expiration in the future → verify badge shows on public view
- [ ] Set expiration in the past → verify strikethrough/opacity on public view
- [ ] Leave expiration empty → verify no change from current behavior
- [ ] Test with exclusive-offer incentive type as well

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)