### PR TITLE
fix(proposal): navigate to proposal view after Update & Preview

### DIFF
--- a/src/features/proposal-flow/ui/views/edit-proposal-view.tsx
+++ b/src/features/proposal-flow/ui/views/edit-proposal-view.tsx
@@ -3,6 +3,7 @@ import type { OverrideProposalValues } from '../../types'
 import type { ProposalFormSchema } from '@/features/proposal-flow/schemas/form-schema'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { motion } from 'motion/react'
+import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
@@ -15,9 +16,11 @@ import { ProposalForm } from '@/features/proposal-flow/ui/components/form'
 import { ErrorState } from '@/shared/components/states/error-state'
 import { LoadingState } from '@/shared/components/states/loading-state'
 import { Form } from '@/shared/components/ui/form'
+import { ROOTS } from '@/shared/config/roots'
 import { CustomerInfoHeader } from '../components/customer-info-header'
 
 export function EditProposalView() {
+  const router = useRouter()
   const [proposalId] = useQueryState('proposalId')
 
   const proposal = useGetProposal(proposalId!, undefined, { enabled: !!proposalId })
@@ -91,6 +94,7 @@ export function EditProposalView() {
     }, {
       onSuccess: () => {
         toast.success('Proposal updated')
+        router.push(`${ROOTS.public.proposals()}/proposal/${proposalId}`)
       },
       onError: (error) => {
         toast.error(error.message)


### PR DESCRIPTION
## Summary
- Added `router.push()` to the `onSuccess` callback of the update mutation in `EditProposalView`, navigating to `/proposal-flow/proposal/{proposalId}` after a successful save
- Matches the existing "Save & Preview" behavior in `CreateNewProposalView`

Closes #17

## Changes
- `src/features/proposal-flow/ui/views/edit-proposal-view.tsx` — added `useRouter`, `ROOTS` import, and `router.push()` in `onSuccess`

## Self-Review
- [x] `tsc --noEmit` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] Diff reviewed — minimal, targeted change

## Test Plan
- [ ] Edit an existing proposal, click "Update & Preview"
- [ ] Verify navigation to the proposal view page after successful save
- [ ] Verify toast still shows "Proposal updated"

🤖 Generated with [Claude Code](https://claude.com/claude-code)