### PR TITLE
feat(proposal): add loading feedback when selecting SOW template

### DIFF
--- a/src/features/proposal-flow/ui/components/form/sow-field.tsx
+++ b/src/features/proposal-flow/ui/components/form/sow-field.tsx
@@ -34,6 +34,7 @@ export function SOWSection({
   const queryClient = useQueryClient()
   const form = useFormContext<ProposalFormSchema>()
   const [tradeId, setTradeId] = useState<string | undefined>(sowSnapshot.trade.id || undefined)
+  const [isLoadingTemplate, setIsLoadingTemplate] = useState(false)
   const tiptapRef = useRef<TiptapHandle | null>(null)
 
   const allTrades = useGetAllTrades()
@@ -198,10 +199,15 @@ export function SOWSection({
                         trade: allTrades.data?.find(trade => trade.id === tradeId),
                         scopes: form.getValues(`project.data.sow.${index}.scopes`).map(scope => scopesOfTrade.data?.find(scopeOfTrade => scopeOfTrade.id === scope.id)).filter(Boolean) as ScopeOrAddon[],
                         onSelect: async (sowId) => {
-                          const json = await queryClient.fetchQuery(trpc.notionRouter.scopes.getSOWContent.queryOptions({ sowId }))
-
-                          tiptapRef.current?.insertContent(JSON.parse(json) || '')
                           closeModal()
+                          setIsLoadingTemplate(true)
+                          try {
+                            const json = await queryClient.fetchQuery(trpc.notionRouter.scopes.getSOWContent.queryOptions({ sowId }))
+                            tiptapRef.current?.insertContent(JSON.parse(json) || '')
+                          }
+                          finally {
+                            setIsLoadingTemplate(false)
+                          }
                         },
                       },
                     })
@@ -214,6 +220,8 @@ export function SOWSection({
               <FormControl>
                 <Tiptap
                   ref={tiptapRef}
+                  isLoading={isLoadingTemplate}
+                  loadingMessage="Loading template from Notion..."
                   onChange={({ html, json }) => {
                     field.onChange(JSON.stringify(json))
                     form.setValue(`project.data.sow.${index}.html`, html)

--- a/src/shared/components/tiptap/tiptap.tsx
+++ b/src/shared/components/tiptap/tiptap.tsx
@@ -9,6 +9,7 @@ import StarterKit from '@tiptap/starter-kit'
 import { BoldIcon, ItalicIcon, StrikethroughIcon } from 'lucide-react'
 import { useImperativeHandle } from 'react'
 import { cn } from '@/shared/lib/utils'
+import { SpinnerLoader2 } from '../loaders/spinner-loader-2'
 import { Button } from '../ui/button'
 import { TipTapMenuBar } from './menu-bar'
 
@@ -21,10 +22,12 @@ export interface TiptapHandle {
 interface Props {
   onChange: ({ html, json }: { html: string, json: any }) => void
   initialValues?: string
+  isLoading?: boolean
+  loadingMessage?: string
   ref?: React.RefObject<TiptapHandle | null>
 }
 
-export function Tiptap({ ref, onChange, initialValues }: Props) {
+export function Tiptap({ ref, onChange, initialValues, isLoading, loadingMessage }: Props) {
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -121,7 +124,7 @@ export function Tiptap({ ref, onChange, initialValues }: Props) {
           <StrikethroughIcon />
         </Button>
       </BubbleMenu>
-      <div className="tiptap w-full min-h-62.5 flex flex-col">
+      <div className="tiptap w-full min-h-62.5 flex flex-col relative">
         <div className="min-h-10 w-full shrink-0">
           <TipTapMenuBar editor={editor} />
         </div>
@@ -131,6 +134,14 @@ export function Tiptap({ ref, onChange, initialValues }: Props) {
           </svg>
         </DragHandle>
         <EditorContent editor={editor} className="grow" />
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/60 backdrop-blur-xs rounded-md z-10">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <SpinnerLoader2 />
+              <span className="text-sm">{loadingMessage ?? 'Loading template...'}</span>
+            </div>
+          </div>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- **Immediately closes** the templates modal when a SOW template is selected (no more stale open modal)
- **Shows a non-blocking spinner overlay** on the TipTap editor while SOW content is fetched from Notion
- Spinner auto-clears on success or failure via `try/finally`
- `Tiptap` component now accepts reusable `isLoading` / `loadingMessage` props

## Changes
- `src/features/proposal-flow/ui/components/form/sow-field.tsx` — restructured `onSelect` to close modal first, track loading state, pass it to Tiptap
- `src/shared/components/tiptap/tiptap.tsx` — added optional `isLoading`/`loadingMessage` props with translucent overlay spinner

## Test plan
- [x] Select a SOW template → modal closes immediately, spinner appears over editor
- [x] Spinner disappears once content loads and is inserted into editor
- [x] Existing editor content remains visible behind the translucent overlay
- [x] If fetch fails, spinner still clears (no stuck loading state)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)