### PR TITLE
fix(proposal): remove scrollbar gap on mobile viewports

### DIFF
--- a/src/features/proposal-flow/ui/views/create-new-proposal-view.tsx
+++ b/src/features/proposal-flow/ui/views/create-new-proposal-view.tsx
@@ -151,7 +151,7 @@ export function CreateNewProposalView() {
           </Button>
         </div>
       </div>
-      <div className="flex-1 min-h-0 w-full overflow-auto pr-4">
+      <div className="flex-1 min-h-0 w-full overflow-auto md:pr-4">
         <Form {...form}>
           <ProposalForm
             isLoading={meetingQuery.isLoading || createProposal.isPending}

--- a/src/features/proposal-flow/ui/views/edit-proposal-view.tsx
+++ b/src/features/proposal-flow/ui/views/edit-proposal-view.tsx
@@ -139,7 +139,7 @@ export function EditProposalView() {
           )}
         </div>
       </div>
-      <div className="h-full w-full overflow-auto pr-4">
+      <div className="h-full w-full overflow-auto md:pr-4">
         <Form {...form}>
           <ProposalForm
             isLoading={proposal.isLoading || updateProposal.isPending}


### PR DESCRIPTION
## Summary
- Changed `pr-4` to `md:pr-4` on scrollable containers in proposal create and edit views
- Mobile browsers now use full width with native overlay scrollbars
- Desktop scrollbar gap preserved at `md` breakpoint and above

Closes #30

## Test Plan
- [x] Check proposal create form on mobile viewport — no scrollbar gap
- [x] Check proposal edit form on mobile viewport — no scrollbar gap
- [x] Verify desktop scrollbar gap still present at md+ viewports
- [x] No visual regression on desktop scrollable areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)