### PR TITLE
feat(customer-pipelines): redesign kanban card with meeting context and assign rep

### DIFF
--- a/src/features/customer-pipelines/dal/server/get-customer-pipeline-items.ts
+++ b/src/features/customer-pipelines/dal/server/get-customer-pipeline-items.ts
@@ -1,4 +1,4 @@
-import type { CustomerPipelineItem, CustomerPipelineRawData } from '@/features/customer-pipelines/types'
+import type { CustomerPipelineItem, CustomerPipelineRawData, PipelineItemRep } from '@/features/customer-pipelines/types'
 
 import type { CustomerPipeline } from '@/shared/types/enums'
 
@@ -6,6 +6,7 @@ import { and, count, desc, eq, inArray, max, sql } from 'drizzle-orm'
 
 import { computeCustomerStage } from '@/features/customer-pipelines/lib/compute-customer-stage'
 import { db } from '@/shared/db'
+import { user } from '@/shared/db/schema/auth'
 import { customers } from '@/shared/db/schema/customers'
 import { meetings } from '@/shared/db/schema/meetings'
 import { proposals } from '@/shared/db/schema/proposals'
@@ -20,6 +21,8 @@ export async function getCustomerPipelineItems(userId: string, pipeline: Custome
         email: customers.email,
         address: customers.address,
         city: customers.city,
+        state: customers.state,
+        zip: customers.zip,
         pipelineStage: customers.pipelineStage,
       })
       .from(customers)
@@ -35,10 +38,15 @@ export async function getCustomerPipelineItems(userId: string, pipeline: Custome
       email: row.email,
       address: row.address,
       city: row.city,
+      state: row.state,
+      zip: row.zip,
       totalPipelineValue: 0,
       meetingCount: 0,
       proposalCount: 0,
       latestActivityAt: '',
+      nextMeetingId: null,
+      nextMeetingAt: null,
+      assignedRep: null,
     }))
   }
 
@@ -50,11 +58,14 @@ export async function getCustomerPipelineItems(userId: string, pipeline: Custome
       customerEmail: customers.email,
       customerAddress: customers.address,
       customerCity: customers.city,
+      customerState: customers.state,
+      customerZip: customers.zip,
       meetingCount: count(meetings.id).as('meeting_count'),
       hasScheduledFutureMeeting: sql<boolean>`bool_or(${meetings.scheduledFor} > now())`.as('has_future_scheduled'),
       hasActiveMeeting: sql<boolean>`bool_or(${meetings.scheduledFor} <= now() AND ${meetings.scheduledFor} > now() - interval '2 hours')`.as('has_active'),
       hasPastMeeting: sql<boolean>`bool_or(${meetings.scheduledFor} <= now() - interval '2 hours' OR (${meetings.scheduledFor} IS NULL AND ${meetings.status} IN ('completed', 'converted')))`.as('has_past'),
       latestMeetingAt: max(meetings.createdAt).as('latest_meeting_at'),
+      nextMeetingAt: sql<string | null>`min(CASE WHEN ${meetings.scheduledFor} > now() - interval '2 hours' THEN ${meetings.scheduledFor} END)`.as('next_meeting_at'),
     })
     .from(customers)
     .leftJoin(meetings, and(
@@ -90,6 +101,33 @@ export async function getCustomerPipelineItems(userId: string, pipeline: Custome
     .groupBy(customers.id)
 
   const proposalMap = new Map(proposalRows.map(r => [r.customerId, r]))
+
+  // Fetch assigned rep + meeting ID: owner of the most relevant meeting (latest by scheduledFor) per customer
+  const repRows = await db
+    .selectDistinctOn([meetings.customerId], {
+      customerId: meetings.customerId,
+      meetingId: meetings.id,
+      repId: user.id,
+      repName: user.name,
+      repEmail: user.email,
+      repImage: user.image,
+    })
+    .from(meetings)
+    .innerJoin(user, eq(user.id, meetings.ownerId))
+    .where(and(
+      inArray(meetings.customerId, customerIds),
+      isOmni ? undefined : eq(meetings.ownerId, userId),
+    ))
+    .orderBy(meetings.customerId, desc(meetings.scheduledFor))
+
+  const repMap = new Map(
+    repRows
+      .filter(r => r.customerId !== null)
+      .map(r => [r.customerId!, {
+        meetingId: r.meetingId,
+        rep: { id: r.repId, name: r.repName, email: r.repEmail, image: r.repImage } as PipelineItemRep,
+      }]),
+  )
 
   return rows.map((row): CustomerPipelineItem => {
     const pData = proposalMap.get(row.customerId)
@@ -135,10 +173,15 @@ export async function getCustomerPipelineItems(userId: string, pipeline: Custome
       email: rawData.customerEmail,
       address: rawData.customerAddress,
       city: rawData.customerCity,
+      state: row.customerState,
+      zip: row.customerZip,
       totalPipelineValue: rawData.totalPipelineValue,
       meetingCount: rawData.meetingCount,
       proposalCount: rawData.proposalCount,
       latestActivityAt: rawData.latestActivityAt,
+      nextMeetingId: repMap.get(row.customerId)?.meetingId ?? null,
+      nextMeetingAt: row.nextMeetingAt ?? null,
+      assignedRep: repMap.get(row.customerId)?.rep ?? null,
     }
   })
 }

--- a/src/features/customer-pipelines/lib/get-meeting-time-label.ts
+++ b/src/features/customer-pipelines/lib/get-meeting-time-label.ts
@@ -1,0 +1,27 @@
+import { formatDistanceToNow } from 'date-fns'
+
+export interface MeetingTimeLabel {
+  text: string
+  variant: 'active' | 'upcoming' | 'past'
+}
+
+export function getMeetingTimeLabel(nextMeetingAt: string | null): MeetingTimeLabel | null {
+  if (!nextMeetingAt) {
+    return null
+  }
+
+  const meetingDate = new Date(nextMeetingAt)
+  const now = new Date()
+  const diffMs = meetingDate.getTime() - now.getTime()
+  const diffHours = diffMs / (1000 * 60 * 60)
+
+  if (diffHours <= 0 && diffHours > -2) {
+    return { text: 'Meeting in progress', variant: 'active' }
+  }
+
+  if (diffHours <= -2) {
+    return { text: formatDistanceToNow(meetingDate, { addSuffix: true }), variant: 'past' }
+  }
+
+  return { text: formatDistanceToNow(meetingDate, { addSuffix: true }), variant: 'upcoming' }
+}

--- a/src/features/customer-pipelines/types/index.ts
+++ b/src/features/customer-pipelines/types/index.ts
@@ -5,6 +5,13 @@ import type { Customer, Meeting, Proposal } from '@/shared/db/schema'
 import type { CustomerNote } from '@/shared/db/schema/customer-notes'
 import type { CustomerProfile, FinancialProfile, PropertyProfile } from '@/shared/entities/customers/schemas'
 
+export interface PipelineItemRep {
+  id: string
+  name: string
+  email: string
+  image: string | null
+}
+
 export interface CustomerPipelineItem {
   id: string
   type: 'customer'
@@ -14,10 +21,15 @@ export interface CustomerPipelineItem {
   email: string | null
   address: string | null
   city: string
+  state: string | null
+  zip: string
   totalPipelineValue: number
   meetingCount: number
   proposalCount: number
   latestActivityAt: string | null
+  nextMeetingId: string | null
+  nextMeetingAt: string | null
+  assignedRep: PipelineItemRep | null
 }
 
 export interface CustomerPipelineRawData {

--- a/src/features/customer-pipelines/ui/components/assign-rep-dialog.tsx
+++ b/src/features/customer-pipelines/ui/components/assign-rep-dialog.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { CheckIcon, SearchIcon } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { RepProfileSnapshot } from '@/shared/components/rep-profile-snapshot'
+import { Button } from '@/shared/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog'
+import { Input } from '@/shared/components/ui/input'
+import { cn } from '@/shared/lib/utils'
+import { useTRPC } from '@/trpc/helpers'
+
+interface AssignRepDialogProps {
+  meetingIds: string[]
+  currentRepId?: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess?: () => void
+}
+
+export function AssignRepDialog({ meetingIds, currentRepId, open, onOpenChange, onSuccess }: AssignRepDialogProps) {
+  const trpc = useTRPC()
+  const [search, setSearch] = useState('')
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+
+  const usersQuery = useQuery({
+    ...trpc.meetingsRouter.getInternalUsers.queryOptions(),
+    enabled: open,
+  })
+
+  const assignMutation = useMutation(
+    trpc.meetingsRouter.assignOwner.mutationOptions({
+      onSuccess: () => {
+        toast.success(meetingIds.length > 1 ? 'Reps assigned successfully' : 'Rep assigned successfully')
+        onOpenChange(false)
+        setSelectedUserId(null)
+        setSearch('')
+        onSuccess?.()
+      },
+      onError: () => {
+        toast.error('Failed to assign rep')
+      },
+    }),
+  )
+
+  function handleAssign() {
+    if (!selectedUserId) {
+      return
+    }
+    // For now, assign one at a time. Bulk will be a batched mutation later.
+    for (const meetingId of meetingIds) {
+      assignMutation.mutate({ meetingId, newOwnerId: selectedUserId })
+    }
+  }
+
+  const filteredUsers = (usersQuery.data ?? []).filter(u =>
+    u.name.toLowerCase().includes(search.toLowerCase())
+    || u.email.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {meetingIds.length > 1 ? `Assign Rep to ${meetingIds.length} Meetings` : 'Assign Rep'}
+          </DialogTitle>
+          <DialogDescription>
+            Select a team member to assign as the meeting rep.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <SearchIcon size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search by name or email..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="max-h-64 overflow-y-auto -mx-1 space-y-0.5">
+          {usersQuery.isLoading && (
+            <p className="text-sm text-muted-foreground text-center py-4">Loading team members...</p>
+          )}
+          {filteredUsers.map(u => (
+            <button
+              key={u.id}
+              type="button"
+              className={cn(
+                'flex items-center gap-2 w-full rounded-md px-3 py-2 text-left transition-colors cursor-pointer',
+                'hover:bg-muted',
+                selectedUserId === u.id && 'bg-primary/10',
+                currentRepId === u.id && 'opacity-60',
+              )}
+              onClick={() => setSelectedUserId(u.id)}
+            >
+              <RepProfileSnapshot
+                name={u.name}
+                image={u.image}
+                subtitle={u.email}
+                className="flex-1"
+              />
+              {selectedUserId === u.id && (
+                <CheckIcon size={16} className="shrink-0 text-primary" />
+              )}
+              {currentRepId === u.id && selectedUserId !== u.id && (
+                <span className="text-[11px] text-muted-foreground shrink-0">Current</span>
+              )}
+            </button>
+          ))}
+          {!usersQuery.isLoading && filteredUsers.length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-4">No team members found</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleAssign}
+            disabled={!selectedUserId || selectedUserId === currentRepId || assignMutation.isPending}
+          >
+            {assignMutation.isPending ? 'Assigning...' : 'Assign'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/customer-pipelines/ui/components/customer-kanban-card.tsx
+++ b/src/features/customer-pipelines/ui/components/customer-kanban-card.tsx
@@ -5,9 +5,27 @@ import type { CustomerPipeline } from '@/shared/types/enums'
 
 import { useDraggable } from '@dnd-kit/core'
 import { formatDistanceToNow } from 'date-fns'
-import { CalendarIcon, FileTextIcon, GripVerticalIcon } from 'lucide-react'
+import {
+  CalendarIcon,
+  DollarSignIcon,
+  ExternalLinkIcon,
+  FileTextIcon,
+  GripVerticalIcon,
+  MapPinIcon,
+  MoreHorizontalIcon,
+  MoreVerticalIcon,
+  Trash2Icon,
+  UserIcon,
+  UserRoundPenIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
 
 import { PIPELINE_LABELS } from '@/features/customer-pipelines/constants/pipeline-labels'
+import { getMeetingTimeLabel } from '@/features/customer-pipelines/lib/get-meeting-time-label'
+import { AddressAction } from '@/shared/components/contact-actions/ui/address-action'
+import { PhoneAction } from '@/shared/components/contact-actions/ui/phone-action'
+import { RepProfileSnapshot } from '@/shared/components/rep-profile-snapshot'
+import { Badge } from '@/shared/components/ui/badge'
 import { Button } from '@/shared/components/ui/button'
 import { Card, CardContent } from '@/shared/components/ui/card'
 import {
@@ -19,9 +37,22 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/shared/components/ui/context-menu'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu'
+import { ROOTS } from '@/shared/config/roots'
 import { customerPipelines } from '@/shared/constants/enums'
 import { useIsMobile } from '@/shared/hooks/use-mobile'
+import { formatAddress, formatAsDollars } from '@/shared/lib/formatters'
 import { cn } from '@/shared/lib/utils'
+import { useAbility } from '@/shared/permissions/hooks'
 
 interface Props {
   item: CustomerPipelineItem
@@ -31,10 +62,23 @@ interface Props {
   onViewProfile: (customerId: string) => void
   onMoveToPipeline?: (customerId: string, pipeline: CustomerPipeline) => void
   onCreateMeeting?: (customerId: string) => void
+  onDeleteCustomer?: (customerId: string) => void
+  onAssignRep?: (meetingId: string, currentRepId: string | null) => void
 }
 
-export function CustomerKanbanCard({ item, currentPipeline, isDragOverlay, canManagePipeline, onViewProfile, onMoveToPipeline, onCreateMeeting }: Props) {
+export function CustomerKanbanCard({
+  item,
+  currentPipeline,
+  isDragOverlay,
+  canManagePipeline,
+  onViewProfile,
+  onMoveToPipeline,
+  onCreateMeeting,
+  onDeleteCustomer,
+  onAssignRep,
+}: Props) {
   const isMobile = useIsMobile()
+  const ability = useAbility()
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: item.id,
     data: item,
@@ -50,60 +94,150 @@ export function CustomerKanbanCard({ item, currentPipeline, isDragOverlay, canMa
   }
 
   const otherPipelines = customerPipelines.filter(p => p !== currentPipeline)
+  const meetingLabel = getMeetingTimeLabel(item.nextMeetingAt)
+  const hasMeetingContext = item.meetingCount > 0 && (item.assignedRep || meetingLabel)
+  const fullAddress = item.address
+    ? formatAddress(item.address, item.city, item.state ?? 'CA', item.zip)
+    : null
 
   const cardContent = (
     <Card
       ref={!isDragOverlay ? setNodeRef : undefined}
       className={cn(
-        'cursor-pointer transition-colors duration-200 hover:bg-primary/5',
+        'cursor-pointer transition-colors duration-200 hover:bg-primary/5 pt-0 pb-0',
         isDragging && !isDragOverlay && 'opacity-30',
         isDragOverlay && 'shadow-lg rotate-1 scale-105',
       )}
       onClick={handleClick}
       {...cardDragProps}
     >
-      <CardContent className="p-3 space-y-1.5">
-        <div className="flex items-center gap-2">
-          {!isDragOverlay && (
-            <span
-              className="shrink-0 cursor-grab active:cursor-grabbing touch-none"
-              {...handleDragProps}
-            >
-              <GripVerticalIcon size={14} className="text-muted-foreground/40" />
-            </span>
-          )}
-          <span className="font-medium text-sm truncate flex-1">
-            {item.name}
-          </span>
+      <CardContent className="p-2.5 space-y-2">
+        {/* ── Customer info container ── */}
+        <div className="rounded-md border border-border/60 bg-muted/30 p-2.5 space-y-1.5 shadow-sm dark:bg-muted/20">
+          {/* Name + created timestamp + more menu */}
+          <div className="flex items-start gap-1.5 min-w-0">
+            {!isDragOverlay && (
+              <span
+                className="shrink-0 cursor-grab active:cursor-grabbing touch-none mt-0.5"
+                {...handleDragProps}
+              >
+                <GripVerticalIcon size={14} className="text-muted-foreground/40" />
+              </span>
+            )}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-1">
+                <span className="font-semibold text-sm truncate uppercase tracking-wide">
+                  {item.name}
+                </span>
+                {!isDragOverlay && (
+                  <CustomerMoreMenu
+                    item={item}
+                    ability={ability}
+                    canManagePipeline={canManagePipeline}
+                    otherPipelines={otherPipelines}
+                    onViewProfile={onViewProfile}
+                    onCreateMeeting={onCreateMeeting}
+                    onMoveToPipeline={onMoveToPipeline}
+                    onDeleteCustomer={onDeleteCustomer}
+                  />
+                )}
+              </div>
+              {item.latestActivityAt && (
+                <p className="text-[11px] text-muted-foreground/70 leading-tight">
+                  {'Created '}
+                  {formatDistanceToNow(new Date(item.latestActivityAt), { addSuffix: true })}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Contact details */}
+          <div
+            className="flex flex-col gap-1.5 text-xs text-muted-foreground"
+            onClick={e => e.stopPropagation()}
+          >
+            {item.phone && <PhoneAction phone={item.phone} className="text-xs" />}
+            {fullAddress && (
+              <AddressAction address={fullAddress}>
+                <button
+                  type="button"
+                  className="flex items-start gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer text-left"
+                  onClick={e => e.stopPropagation()}
+                >
+                  <MapPinIcon size={14} className="shrink-0 mt-0.5" />
+                  <span className="whitespace-pre-line leading-snug">{fullAddress}</span>
+                </button>
+              </AddressAction>
+            )}
+          </div>
         </div>
 
-        {item.totalPipelineValue > 0 && (
-          <p className="text-sm font-semibold text-green-600">
-            $
-            {item.totalPipelineValue.toLocaleString()}
-          </p>
+        {/* ── Meeting context container ── */}
+        {hasMeetingContext && (
+          <div className="rounded-md border border-border/50 bg-accent/50 p-2.5 space-y-1.5 shadow-sm dark:bg-accent/30">
+            {/* Rep (top) + meeting more menu */}
+            <div className="flex items-center gap-1.5 min-w-0">
+              <div className="flex-1 min-w-0">
+                {item.assignedRep && (
+                  <RepProfileSnapshot
+                    name={item.assignedRep.name}
+                    image={item.assignedRep.image}
+                    subtitle={item.assignedRep.email}
+                  />
+                )}
+              </div>
+              {!isDragOverlay && item.nextMeetingId && (
+                <MeetingMoreMenu
+                  item={item}
+                  ability={ability}
+                  onAssignRep={onAssignRep}
+                />
+              )}
+            </div>
+
+            {/* Proposal count */}
+            {item.proposalCount > 0 && (
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                <FileTextIcon size={11} />
+                <span>
+                  {item.proposalCount}
+                  {' '}
+                  {item.proposalCount === 1 ? 'proposal' : 'proposals'}
+                </span>
+              </div>
+            )}
+
+            {/* Scheduled for badge (bottom of meeting group) */}
+            {meetingLabel && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'gap-1 text-[11px] font-normal w-fit',
+                  meetingLabel.variant === 'active' && 'border-yellow-500/30 bg-yellow-500/10 text-yellow-700 dark:border-yellow-500/20 dark:bg-yellow-500/10 dark:text-yellow-300',
+                  meetingLabel.variant === 'upcoming' && 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-300',
+                  meetingLabel.variant === 'past' && 'border-muted-foreground/20 text-muted-foreground',
+                )}
+              >
+                <CalendarIcon size={10} />
+                {meetingLabel.text}
+              </Badge>
+            )}
+          </div>
         )}
 
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <span className="flex items-center gap-0.5">
-            <CalendarIcon size={11} />
-            {item.meetingCount}
-          </span>
-          <span className="flex items-center gap-0.5">
-            <FileTextIcon size={11} />
-            {item.proposalCount}
-          </span>
-          {item.latestActivityAt && (
-            <span className="ml-auto text-[11px] text-muted-foreground/70">
-              {formatDistanceToNow(new Date(item.latestActivityAt), { addSuffix: true })}
-            </span>
-          )}
-        </div>
+        {/* ── Pipeline value (if any) ── */}
+        {item.totalPipelineValue > 0 && (
+          <div className="flex items-center gap-0.5 text-xs font-semibold text-green-700 dark:text-green-400 px-0.5">
+            <DollarSignIcon size={12} />
+            {formatAsDollars(item.totalPipelineValue)}
+          </div>
+        )}
 
+        {/* CTA: Schedule Meeting for needs_confirmation */}
         {item.stage === 'needs_confirmation' && onCreateMeeting && (
           <Button
             size="sm"
-            className="w-full mt-1"
+            className="w-full"
             onClick={(e) => {
               e.stopPropagation()
               onCreateMeeting(item.id)
@@ -142,4 +276,112 @@ export function CustomerKanbanCard({ item, currentPipeline, isDragOverlay, canMa
   }
 
   return cardContent
+}
+
+/* ── Sub-components ── */
+
+function CustomerMoreMenu({ item, ability, canManagePipeline, otherPipelines, onViewProfile, onCreateMeeting, onMoveToPipeline, onDeleteCustomer }: {
+  item: CustomerPipelineItem
+  ability: ReturnType<typeof useAbility>
+  canManagePipeline?: boolean
+  otherPipelines: CustomerPipeline[]
+  onViewProfile: (id: string) => void
+  onCreateMeeting?: (id: string) => void
+  onMoveToPipeline?: (id: string, p: CustomerPipeline) => void
+  onDeleteCustomer?: (id: string) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 p-0.5 rounded-sm hover:bg-background/80 transition-colors cursor-pointer"
+          onClick={e => e.stopPropagation()}
+        >
+          <MoreVerticalIcon size={14} className="text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={e => e.stopPropagation()}>
+        <DropdownMenuItem onClick={() => onViewProfile(item.id)}>
+          <UserIcon size={14} />
+          View Profile
+        </DropdownMenuItem>
+        {ability.can('create', 'Meeting') && onCreateMeeting && (
+          <DropdownMenuItem onClick={() => onCreateMeeting(item.id)}>
+            <CalendarIcon size={14} />
+            Schedule Meeting
+          </DropdownMenuItem>
+        )}
+        {canManagePipeline && onMoveToPipeline && otherPipelines.length > 0 && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Move to Pipeline</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {otherPipelines.map(p => (
+                <DropdownMenuItem key={p} onClick={() => onMoveToPipeline(item.id, p)}>
+                  {PIPELINE_LABELS[p]}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
+        {ability.can('delete', 'Customer') && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => {
+                if (onDeleteCustomer) {
+                  onDeleteCustomer(item.id)
+                }
+                else {
+                  toast.info('Delete customer is not yet implemented')
+                }
+              }}
+            >
+              <Trash2Icon size={14} />
+              Delete Customer
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function MeetingMoreMenu({ item, ability, onAssignRep }: {
+  item: CustomerPipelineItem
+  ability: ReturnType<typeof useAbility>
+  onAssignRep?: (meetingId: string, currentRepId: string | null) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 p-0.5 rounded-sm hover:bg-background/80 transition-colors cursor-pointer"
+          onClick={e => e.stopPropagation()}
+        >
+          <MoreHorizontalIcon size={14} className="text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={e => e.stopPropagation()}>
+        {ability.can('read', 'Meeting') && (
+          <DropdownMenuItem asChild>
+            <a href={`${ROOTS.dashboard.meetings()}/${item.nextMeetingId}`}>
+              <ExternalLinkIcon size={14} />
+              Open Meeting
+            </a>
+          </DropdownMenuItem>
+        )}
+        {ability.can('assign', 'Meeting') && onAssignRep && item.nextMeetingId && (
+          <DropdownMenuItem
+            onClick={() => onAssignRep(item.nextMeetingId!, item.assignedRep?.id ?? null)}
+          >
+            <UserRoundPenIcon size={14} />
+            Assign Rep
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 }

--- a/src/features/customer-pipelines/ui/views/customer-pipeline-view.tsx
+++ b/src/features/customer-pipelines/ui/views/customer-pipeline-view.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner'
 import { ActionCenterSheet } from '@/features/agent-dashboard/ui/components/action-center-sheet'
 import { pipelineConfigs } from '@/features/customer-pipelines/constants/pipeline-config'
 import { groupCustomersByStage } from '@/features/customer-pipelines/lib/group-customers-by-stage'
+import { AssignRepDialog } from '@/features/customer-pipelines/ui/components/assign-rep-dialog'
 import { CustomerKanbanCard } from '@/features/customer-pipelines/ui/components/customer-kanban-card'
 import { CustomerPipelineMetricsBar } from '@/features/customer-pipelines/ui/components/customer-pipeline-metrics-bar'
 import { CustomerPipelineTable } from '@/features/customer-pipelines/ui/components/customer-pipeline-table'
@@ -36,6 +37,7 @@ export function CustomerPipelineView() {
   const [layout, setLayout] = useState<DataViewType>('kanban')
   const [pipeline, setPipeline] = useState<CustomerPipeline>('active')
   const [createMeetingForCustomer, setCreateMeetingForCustomer] = useState<{ id: string, name: string } | null>(null)
+  const [assignRepTarget, setAssignRepTarget] = useState<{ meetingIds: string[], currentRepId: string | null } | null>(null)
   const trpc = useTRPC()
   const { open: openModal, setModal } = useModalStore()
   const ability = useAbility()
@@ -122,6 +124,13 @@ export function CustomerPipelineView() {
     return item.totalPipelineValue > 0 ? item.totalPipelineValue : null
   }
 
+  const handleAssignRep = useCallback((meetingId: string, currentRepId: string | null) => {
+    setAssignRepTarget({ meetingIds: [meetingId], currentRepId })
+  }, [])
+
+  // TODO: Wire up when deleteCustomer tRPC procedure is implemented
+  // const handleDeleteCustomer = useCallback((customerId: string) => { ... }, [])
+
   const renderCard = useCallback(
     (item: CustomerPipelineItem, _href: string, isDragOverlay?: boolean) => (
       <CustomerKanbanCard
@@ -132,9 +141,10 @@ export function CustomerPipelineView() {
         onViewProfile={handleViewProfile}
         onMoveToPipeline={handleMoveToPipeline}
         onCreateMeeting={handleCreateMeeting}
+        onAssignRep={handleAssignRep}
       />
     ),
-    [handleViewProfile, handleMoveToPipeline, handleCreateMeeting, pipeline, canManagePipeline],
+    [handleViewProfile, handleMoveToPipeline, handleCreateMeeting, handleAssignRep, pipeline, canManagePipeline],
   )
 
   const isInitialLoad = pipelineQuery.isLoading && !pipelineQuery.data
@@ -232,6 +242,15 @@ export function CustomerPipelineView() {
           onSuccess={() => pipelineQuery.refetch()}
           customerId={createMeetingForCustomer.id}
           customerName={createMeetingForCustomer.name}
+        />
+      )}
+      {assignRepTarget && (
+        <AssignRepDialog
+          meetingIds={assignRepTarget.meetingIds}
+          currentRepId={assignRepTarget.currentRepId}
+          open={!!assignRepTarget}
+          onOpenChange={open => !open && setAssignRepTarget(null)}
+          onSuccess={() => pipelineQuery.refetch()}
         />
       )}
       <ActionCenterSheet

--- a/src/shared/components/rep-profile-snapshot.tsx
+++ b/src/shared/components/rep-profile-snapshot.tsx
@@ -1,0 +1,36 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/ui/avatar'
+import { cn } from '@/shared/lib/utils'
+
+interface RepProfileSnapshotProps {
+  className?: string
+  image: string | null
+  name: string
+  subtitle?: string
+  subtitleClassName?: string
+}
+
+export function RepProfileSnapshot({ className, image, name, subtitle, subtitleClassName }: RepProfileSnapshotProps) {
+  const initials = name
+    .split(' ')
+    .map(n => n.charAt(0))
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  return (
+    <div className={cn('flex items-center gap-2 min-w-0', className)}>
+      <Avatar className="size-5 shrink-0">
+        <AvatarImage src={image ?? undefined} alt={name} />
+        <AvatarFallback className="text-[9px] font-medium">
+          {initials}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium truncate leading-tight">{name}</p>
+        {subtitle && (
+          <p className={cn('text-[11px] text-muted-foreground truncate leading-tight', subtitleClassName)}>{subtitle}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/shared/lib/formatters.ts
+++ b/src/shared/lib/formatters.ts
@@ -11,8 +11,7 @@ export function formatAsPhoneNumber(phone: string) {
 }
 
 export function formatAddress(address: string, city: string, state: string, zipCode: string) {
-  return `${address}, 
-  ${city}, ${state}, ${zipCode}`
+  return `${address},\n${city}, ${state}, ${zipCode}`
 }
 
 export function formatStringAsDate(stringDate: string, options: Intl.DateTimeFormatOptions = {}) {


### PR DESCRIPTION
## Summary
- Redesigned customer pipeline kanban cards with two clear sections: customer info container (name, phone, address) and meeting context container (assigned rep, proposal count, scheduled time badge)
- Added `RepProfileSnapshot` shared component for displaying agent avatar + name + subtitle
- Added `AssignRepDialog` with CASL-gated assign functionality (super-admin only) using existing `meetingsRouter.assignOwner` backend
- DAL now joins `user` table for rep data and selects `state`/`zip` for full address formatting
- All colors use dark-mode-safe variants (`dark:` prefixes), address renders on 2 lines, touch-friendly spacing

## Changes
- **New:** `src/shared/components/rep-profile-snapshot.tsx` — reusable avatar + name + subtitle
- **New:** `src/features/customer-pipelines/ui/components/assign-rep-dialog.tsx` — rep assignment dialog
- **New:** `src/features/customer-pipelines/lib/get-meeting-time-label.ts` — meeting time badge logic
- **Modified:** `customer-kanban-card.tsx` — full card redesign with customer/meeting containers, moreVertical/moreHorizontal menus
- **Modified:** `get-customer-pipeline-items.ts` — joins user table, selects rep/state/zip/meetingId
- **Modified:** `customer-pipeline-view.tsx` — wires AssignRepDialog + onAssignRep callback
- **Modified:** `types/index.ts` — added `PipelineItemRep`, `nextMeetingId`, `nextMeetingAt`, `state`, `zip`
- **Modified:** `formatters.ts` — `formatAddress` now returns 2-line string

## Self-Review
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Reviewed diff for correctness

## Test Plan
- [ ] Verify kanban cards display customer info (name, phone, 2-line address) in bordered container
- [ ] Verify meeting context shows rep avatar, email, proposal count, and scheduled-for badge
- [ ] Verify moreVertical menu: View Profile, Schedule Meeting, Move to Pipeline, Delete Customer (super-admin only)
- [ ] Verify moreHorizontal menu: Open Meeting, Assign Rep (super-admin only)
- [ ] Verify Assign Rep dialog lists agents and reassigns meeting owner
- [ ] Test light mode and dark mode color rendering
- [ ] Test mobile layout (touch-friendly spacing, grip handle drag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)