### PR TITLE
chore(scripts): add idempotent meeting_participants backfill

### DIFF
--- a/scripts/backfill-meeting-participants.ts
+++ b/scripts/backfill-meeting-participants.ts
@@ -1,0 +1,80 @@
+/**
+ * One-time backfill: populate `meeting_participants` from existing `meetings.owner_id`.
+ *
+ * Run AFTER the schema push that creates the `meeting_participants` table and
+ * BEFORE deploying the new participant-aware code. Without this, the new
+ * visibility filter (`userParticipatesInMeeting`) returns false for existing
+ * meetings and agents lose visibility of their past meetings.
+ *
+ * Idempotent — safe to re-run. The partial unique index
+ * `meeting_one_owner_idx` rejects duplicates atomically.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-meeting-participants.ts
+ */
+import 'dotenv/config'
+import { sql } from 'drizzle-orm'
+import { db } from '@/shared/db'
+
+async function main() {
+  console.log('--- BEFORE ---')
+  const before = await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM meetings WHERE owner_id IS NOT NULL) AS meetings_with_owner,
+      (SELECT count(*) FROM meeting_participants WHERE role = 'owner') AS owner_participant_rows
+  `)
+  console.log(JSON.stringify(before.rows, null, 2))
+
+  console.log('\n--- BACKFILLING ---')
+  const result = await db.execute(sql`
+    INSERT INTO meeting_participants (id, meeting_id, user_id, role, created_at, updated_at)
+    SELECT
+      gen_random_uuid(),
+      m.id,
+      m.owner_id,
+      'owner',
+      NOW(),
+      NOW()
+    FROM meetings m
+    WHERE m.owner_id IS NOT NULL
+    ON CONFLICT DO NOTHING
+    RETURNING meeting_id
+  `)
+  console.log(`Inserted ${result.rows.length} owner participant rows.`)
+
+  console.log('\n--- AFTER ---')
+  const after = await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM meetings WHERE owner_id IS NOT NULL) AS meetings_with_owner,
+      (SELECT count(*) FROM meeting_participants WHERE role = 'owner') AS owner_participant_rows
+  `)
+  console.log(JSON.stringify(after.rows, null, 2))
+
+  const a = after.rows[0] as { meetings_with_owner: string, owner_participant_rows: string }
+  if (a.meetings_with_owner !== a.owner_participant_rows) {
+    console.error('\nFAIL: counts do not match. Some meetings still lack an owner participant row.')
+    process.exit(1)
+  }
+
+  console.log('\n--- DUPLICATE CHECK ---')
+  const dupes = await db.execute(sql`
+    SELECT meeting_id, role, count(*) AS n
+    FROM meeting_participants
+    GROUP BY meeting_id, role
+    HAVING count(*) > 1
+  `)
+  if (dupes.rows.length > 0) {
+    console.error('FAIL: duplicate (meeting_id, role) rows exist:')
+    console.error(JSON.stringify(dupes.rows, null, 2))
+    process.exit(1)
+  }
+  console.log('No duplicates.')
+
+  console.log('\nBackfill complete.')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Follow-up to #81. Adds the prod-deploy backfill script that should have been part of that PR but landed after the merge.

## Why this is required for prod deploy

The merged PR migrated ownership/visibility filters from `eq(meetings.ownerId, userId)` → `userParticipatesInMeeting(userId, meetingId)`. After the schema push but before backfill:
- Existing meetings have `meetings.owner_id` set but **zero rows** in `meeting_participants`
- The new visibility filter returns `false` for those meetings
- Non-super-admin agents lose visibility of all their past meetings

This script populates the junction so the new filter works correctly.

## What it does

- Reads count of meetings with `owner_id IS NOT NULL`
- INSERTs `(meeting_id, user_id, 'owner')` rows for each, `ON CONFLICT DO NOTHING`
- Verifies post-counts match pre-counts
- Verifies no duplicate `(meeting_id, role)` rows exist (would indicate the partial unique indexes from #81 caught a problem)
- Exits non-zero if any check fails

Idempotent — safe to re-run.

## Verified on dev

```
--- BEFORE ---
{"meetings_with_owner": "81", "owner_participant_rows": "81"}

--- BACKFILLING ---
Inserted 0 owner participant rows.

--- AFTER ---
{"meetings_with_owner": "81", "owner_participant_rows": "81"}

--- DUPLICATE CHECK ---
No duplicates.

Backfill complete.
```

(Dev is already backfilled from earlier in development. Prod will see the actual inserts.)

## Required prod deploy sequence (after this merges)

```bash
# 1. Push schema (creates meeting_participants + partial unique indexes)
pnpm db:push   # against prod

# 2. Backfill
pnpm tsx scripts/backfill-meeting-participants.ts

# 3. Deploy new code (Vercel/etc)
```

If steps 1+2 happen before code deploy, there is no visibility gap for agents.

## Test Plan

- [x] Dry-run on dev DB (already backfilled) — script reports 0 inserts and passes verification
- [ ] Run against prod during deploy window — expect inserts equal to count of `meetings WHERE owner_id IS NOT NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)