### PR TITLE
fix(customers): polish customer profile hero for PWA + mobile

### DIFF
--- a/src/shared/entities/customers/components/profile/customer-hero-header.tsx
+++ b/src/shared/entities/customers/components/profile/customer-hero-header.tsx
@@ -30,6 +30,7 @@ import { canAgentSeePhone } from '@/shared/entities/customers/lib/can-see-phone'
 import { getInitials } from '@/shared/entities/users/lib/get-initials'
 import { copyToClipboard } from '@/shared/lib/clipboard'
 import { formatAsPhoneNumber, formatCustomerAddress } from '@/shared/lib/formatters'
+import { openExternalUrl } from '@/shared/lib/pwa'
 import { cn } from '@/shared/lib/utils'
 import { AddressEditDialog } from './address-edit-dialog'
 
@@ -74,9 +75,13 @@ export function CustomerHeroHeader({ customer, editForm }: Props) {
         <div className="flex items-center gap-1.5">
           {editForm.isEditing && canEditContact
             ? (
+                // Bounded width keeps the save/cancel buttons visually anchored
+                // close to where the pencil sat — the input never fills the
+                // whole row, so there is minimal layout shift between display
+                // and edit modes. Width is stable regardless of typed content.
                 <Input
                   {...editForm.form.register('name')}
-                  className="h-8 flex-1 bg-white/10 text-lg font-semibold tracking-tight text-white placeholder:text-white/50 sm:text-xl"
+                  className="h-8 w-full max-w-64 bg-white/10 text-lg font-semibold tracking-tight text-white placeholder:text-white/50 sm:max-w-80 sm:text-xl"
                   placeholder="Customer name"
                 />
               )
@@ -183,22 +188,19 @@ function AddressBadge({ address, canEdit, onEdit }: AddressBadgeProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button type="button" className={cn(BADGE_BASE, 'items-start sm:items-center')} onClick={e => e.stopPropagation()}>
-          <MapPinIcon className="mt-0.5 size-3.5 shrink-0 text-white/80 sm:mt-0" />
-          {/* Mobile: stacked line1/line2. Desktop: single line for compactness. */}
-          <span className="flex flex-col items-start text-left sm:hidden">
-            <span className="leading-tight">{address.line1 || address.line2}</span>
-            {address.line1 && address.line2 && <span className="leading-tight text-white/75">{address.line2}</span>}
-          </span>
-          <span className="hidden max-w-95 truncate sm:inline">{address.singleLine}</span>
+        <button type="button" className={BADGE_BASE} onClick={e => e.stopPropagation()}>
+          <MapPinIcon className="size-3.5 shrink-0 text-white/80" />
+          {/* Single-line across all breakpoints — truncation keeps the badge
+              shape consistent with phone/email. On mobile the column stacks
+              badges, so a narrower cap prevents the row from blowing out. */}
+          <span className="max-w-52 truncate sm:max-w-95">{address.singleLine}</span>
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         <DropdownMenuItem
           onClick={() => {
-            window.open(
+            openExternalUrl(
               `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address.singleLine)}`,
-              '_blank',
             )
           }}
         >
@@ -207,9 +209,8 @@ function AddressBadge({ address, canEdit, onEdit }: AddressBadgeProps) {
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => {
-            window.open(
+            openExternalUrl(
               `https://earth.google.com/web/search/${encodeURIComponent(address.singleLine)}`,
-              '_blank',
             )
           }}
         >

--- a/src/shared/entities/customers/components/profile/customer-profile-modal-content.tsx
+++ b/src/shared/entities/customers/components/profile/customer-profile-modal-content.tsx
@@ -38,11 +38,15 @@ export function CustomerProfileModalContent({ data, defaultTab, heroAddress, her
 
           {/* Content fills the hero band and stacks from the bottom.
               - px/pb are the "base" padding, matched on all three sides
-              - pt is slightly larger for visual breathing room at the top
-              - On mobile the hero is content-dictated (no min-h), so content
-                sits near the top with minimal padding above it. On desktop,
-                sm:min-h-72 + justify-end parks the tabs at the bottom. */}
-          <div className="relative z-10 flex flex-1 flex-col justify-end gap-4 px-4 pb-4 pt-10 text-white sm:px-6 sm:pb-6">
+              - pt respects the iOS safe-area (notch / Dynamic Island) so the
+                floating X + view-toggle chrome never overlaps the header
+                content on PWA. On non-iOS / browsers without a safe-area,
+                env() resolves to 0 and this collapses to the original 2.5rem.
+              - The map backdrop (absolute inset-0) intentionally extends
+                edge-to-edge including behind the notch — only the content
+                is pushed down by safe-area. This also makes the hero taller
+                on iOS PWA, which is the desired effect. */}
+          <div className="relative z-10 flex flex-1 flex-col justify-end gap-4 px-4 pb-4 pt-[calc(env(safe-area-inset-top)+4.25rem)] text-white sm:px-6 sm:pb-6 sm:pt-10">
             <CustomerHeroHeader customer={data.customer} editForm={editForm} />
 
             {profile && <CustomerProfileKeyInsights profile={profile} />}

--- a/src/shared/lib/pwa.ts
+++ b/src/shared/lib/pwa.ts
@@ -1,0 +1,51 @@
+/**
+ * PWA / standalone-display helpers.
+ *
+ * The same hostname behaves very differently depending on where it's loaded:
+ * a click to https://maps.google.com from a browser tab wants a new tab,
+ * but from an iOS standalone PWA it should route through the OS so iOS can
+ * hand the URL to the Google Maps app via universal links.
+ */
+
+/**
+ * True when the app is running as an installed PWA in standalone mode.
+ *
+ * Checks both the CSS media query (Android / desktop Chrome) and the
+ * Safari-specific `navigator.standalone` flag (iOS). SSR-safe — returns
+ * false on the server so the caller can rely on it during render.
+ */
+export function isStandalonePWA(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  return (
+    window.matchMedia('(display-mode: standalone)').matches
+    || ('standalone' in navigator && (navigator as { standalone?: boolean }).standalone === true)
+  )
+}
+
+/**
+ * Open an external URL, picking the right strategy for the current runtime.
+ *
+ * - In a browser tab: opens in a new tab so the user's current context
+ *   (our app) is preserved.
+ * - In an installed PWA (iOS/Android standalone): uses `location.href` so
+ *   the OS can route the navigation through its universal-link handler
+ *   (e.g. https://maps.google.com/... opens the Google Maps app directly).
+ *   Using `window.open('_blank')` in standalone mode creates a blank
+ *   internal window that lingers in the PWA after the OS hands off to the
+ *   native app — bad UX. `location.href` lets iOS intercept cleanly.
+ *
+ * Fallback behaviour in the rare case a universal link doesn't match: the
+ * PWA will navigate to the URL in-window; the user can swipe-back to return.
+ */
+export function openExternalUrl(url: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  if (isStandalonePWA()) {
+    window.location.href = url
+    return
+  }
+  window.open(url, '_blank', 'noopener,noreferrer')
+}


### PR DESCRIPTION
## Summary

Polish pass on the customer profile modal's hero section, focused on iOS PWA behavior and small UX papercuts.

## Changes

- **Safe-area respect on iOS PWA** — Hero content padding switches to `pt-[calc(env(safe-area-inset-top)+4.25rem)]`. The map backdrop still extends edge-to-edge (including behind the notch / Dynamic Island); only the header content is pushed below the safe area. On non-iOS / browsers without a safe area, env() resolves to 0 so the mobile pt collapses to 68px.
- **Mobile top padding ~30% taller** — Bumped the constant from `2.5rem` to `4.25rem`. Desktop pinned at `sm:pt-10` (no regression).
- **Address badge is single-line everywhere** — Dropped the mobile `line1/line2` stacked variant. Now uses `singleLine` with `max-w-52 sm:max-w-95` truncate, matching phone/email badge shape.
- **Name input bounded width** — Replaced `flex-1` with `w-full max-w-64 sm:max-w-80`, so the save button lands close to where the pencil was. Minimal layout shift between display ↔ edit modes, and stable as the user types.
- **PWA-aware external URL opening** — New `src/shared/lib/pwa.ts` exports `isStandalonePWA()` + `openExternalUrl(url)`. The "Open in Google Maps / Google Earth" dropdown items now use it: in a browser it still opens a new tab; in standalone PWA it uses `location.href` so iOS can hand off to the Google apps via universal links without leaving a blank PWA window behind.

## Self-review

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — no new warnings on changed files
- [x] No schema changes
- [x] No new env vars

## Test plan

- [ ] Open a customer profile on iOS PWA — map extends behind the notch, name + badges clear the safe area
- [ ] Same on desktop — no visible change (still `pt-10`)
- [ ] On mobile (PWA + browser), the address badge renders on one line with truncation
- [ ] Click pencil → name input is bounded (not full-width); save/cancel buttons land near the pencil's original spot
- [ ] In browser: "Open in Google Maps" opens a new tab
- [ ] In iOS PWA: "Open in Google Maps" hands off to the Google Maps app (or Safari fallback) without leaving a blank window to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)