### PR TITLE
fix(scripts): make rebuild-gcal-descriptions runnable from CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "migrate:notes:dev": "DRIZZLE_TARGET=dev tsx scripts/migrate-notes-to-activities.ts",
     "migrate:notion": "tsx scripts/migrate-notion-contacts.ts",
     "migrate:notion:dev": "DRIZZLE_TARGET=dev tsx scripts/migrate-notion-contacts.ts",
+    "rebuild:gcal": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
+    "rebuild:gcal:dev": "DRIZZLE_TARGET=dev NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
     "meta": "tsx scripts/meta/index.ts",
     "dispatch": "bash scripts/dispatch.sh",
     "tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app 3000"

--- a/scripts/rebuild-gcal-descriptions.ts
+++ b/scripts/rebuild-gcal-descriptions.ts
@@ -13,9 +13,17 @@
  * Throttled to 10 req/sec (well under Google Calendar's 100/sec hard quota)
  * so it won't trigger rate limiting even on large datasets.
  *
- * Usage:
- *   pnpm tsx scripts/rebuild-gcal-descriptions.ts
- *   pnpm tsx scripts/rebuild-gcal-descriptions.ts --dry-run
+ * Usage (pnpm scripts set the required NODE_OPTIONS flag):
+ *   pnpm rebuild:gcal:dev -- --dry-run   # dev DB, count only
+ *   pnpm rebuild:gcal:dev                # dev DB, real run
+ *   pnpm rebuild:gcal -- --dry-run       # prod DB, count only
+ *   pnpm rebuild:gcal                    # prod DB, real run
+ *
+ * The `--conditions=react-server` Node flag (set by the pnpm scripts) makes
+ * `server-only` resolve to its no-op `empty.js` export, which lets this CLI
+ * import `schedulingService` — and its transitive `server-only` imports —
+ * without needing the Next.js webpack alias that normally provides that
+ * behavior inside the running app.
  */
 import 'dotenv/config'
 import { isNotNull } from 'drizzle-orm'


### PR DESCRIPTION
## Summary
Companion fix for #87. Running the script blew up at load time because [scheduling.service.ts:33](src/shared/services/scheduling.service.ts#L33) transitively imports `refresh-access-token.ts` which declares `import 'server-only'`. Outside the Next.js runtime, that package throws on load.

## Fix
Node's `--conditions=react-server` flag activates the `react-server` export in [node_modules/server-only/package.json](node_modules/server-only/package.json), which resolves to the no-op `empty.js` — the exact same behavior Next achieves in its server bundle via webpack alias.

Wired as pnpm scripts so the user doesn't have to remember the flag:

```bash
pnpm rebuild:gcal:dev -- --dry-run   # dev DB, count only
pnpm rebuild:gcal:dev                # dev DB, real run
pnpm rebuild:gcal -- --dry-run       # prod DB, count only
pnpm rebuild:gcal                    # prod DB, real run
```

Verified against dev DB — found **81 synced meetings**, dry-run exits cleanly.

## Why this is clean
No source code changes, no runtime shims, no custom loaders. It's the mechanism Next itself uses — we're just opting into it for the CLI runner.

## Self-Review
- [x] `pnpm tsc --noEmit` unaffected
- [x] Dry-run succeeds against dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)