### PR TITLE
fix(scripts): rebuild:gcal must set NODE_ENV=production to hit prod DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "migrate:notes:dev": "DRIZZLE_TARGET=dev tsx scripts/migrate-notes-to-activities.ts",
     "migrate:notion": "tsx scripts/migrate-notion-contacts.ts",
     "migrate:notion:dev": "DRIZZLE_TARGET=dev tsx scripts/migrate-notion-contacts.ts",
-    "rebuild:gcal": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
-    "rebuild:gcal:dev": "DRIZZLE_TARGET=dev NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
+    "rebuild:gcal": "NODE_ENV=production NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
+    "rebuild:gcal:dev": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
     "meta": "tsx scripts/meta/index.ts",
     "dispatch": "bash scripts/dispatch.sh",
     "tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app 3000"

--- a/scripts/rebuild-gcal-descriptions.ts
+++ b/scripts/rebuild-gcal-descriptions.ts
@@ -34,10 +34,39 @@ import { schedulingService } from '@/shared/services/scheduling.service'
 
 const THROTTLE_MS = 100
 
+/**
+ * The runtime DB client at src/shared/db/index.ts picks between DATABASE_URL
+ * (prod) and DATABASE_DEV_URL based on NODE_ENV, NOT DRIZZLE_TARGET. That
+ * makes it easy to accidentally run this against the wrong DB. Surface the
+ * exact host + NODE_ENV at the start of every run so the operator can abort
+ * if it's not what they expected.
+ */
+function describeTargetDb(): { env: string, host: string } {
+  const nodeEnv = process.env.NODE_ENV ?? '(unset)'
+  const isProd = process.env.NODE_ENV === 'production'
+  const raw = isProd
+    ? process.env.DATABASE_URL
+    : (process.env.DATABASE_DEV_URL ?? process.env.DATABASE_URL)
+  let host = '(unknown)'
+  if (raw) {
+    try {
+      host = new URL(raw).host
+    }
+    catch {
+      host = '(unparseable)'
+    }
+  }
+  return { env: nodeEnv, host }
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run')
+  const { env, host } = describeTargetDb()
 
   console.log(`--- REBUILD GCAL DESCRIPTIONS${dryRun ? ' (dry run)' : ''} ---`)
+  console.log(`NODE_ENV: ${env}`)
+  console.log(`DB host:  ${host}`)
+  console.log('')
 
   const systemOwnerId = await getSystemOwnerId()
 


### PR DESCRIPTION
## Summary
Both `pnpm rebuild:gcal` and `pnpm rebuild:gcal:dev` were silently hitting the **dev** DB because the runtime client at [src/shared/db/index.ts:7](src/shared/db/index.ts#L7) picks between `DATABASE_URL` and `DATABASE_DEV_URL` based on `NODE_ENV`, not `DRIZZLE_TARGET`. `DRIZZLE_TARGET` is only consumed by `drizzle.config.ts` for `drizzle-kit push/generate`.

So: every prior "prod" run actually re-pushed dev events. Prod GCal descriptions were never touched.

## Fix
- `rebuild:gcal` sets `NODE_ENV=production` so the runtime DB client picks `DATABASE_URL`
- `rebuild:gcal:dev` drops the inert `DRIZZLE_TARGET` — relies on the default (unset) `NODE_ENV` which makes the client pick `DATABASE_DEV_URL`
- Script now logs `NODE_ENV` + resolved DB host at startup so the operator can abort early if targeting the wrong environment

## Verified locally
```
pnpm rebuild:gcal:dev -- --dry-run
  NODE_ENV: (unset)
  DB host:  ep-mute-sunset-afxp3pn5-pooler... (dev)
  Found 81 synced meetings.

pnpm rebuild:gcal -- --dry-run
  NODE_ENV: production
  DB host:  ep-flat-wind-afvc0zla-pooler... (prod)
  Found 103 synced meetings.
```

## Followup after merge
Run `pnpm rebuild:gcal` to actually update prod's 103 synced meetings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)