### PR TITLE
fix(scripts): self-heal orphan GCal event IDs during rebuild

### DIFF
--- a/scripts/rebuild-gcal-descriptions.ts
+++ b/scripts/rebuild-gcal-descriptions.ts
@@ -1,14 +1,25 @@
 /**
- * One-time re-push: update every synced meeting's GCal event so its
- * description picks up the new `/schedule?highlightMeeting=...&highlightDate=...`
- * deep link (replacing the legacy `/dashboard/meetings/:id` link).
+ * Rebuild every synced meeting's GCal event description from the current DB
+ * state, and self-heal any meetings whose gcal_event_id points at a deleted
+ * GCal event.
  *
- * Run ONCE after deploying the meeting polish batch (PR #84). The
- * centralized `pushToGCal` path for meetings always calls updateEvent when
- * `gcalEventId` is already set, so re-pushing rewrites the description
- * (plus every other field) from the current DB state.
+ * Originally written to migrate the GCal description deep link from
+ * `/dashboard/meetings/:id` to `/schedule?highlightMeeting=...&highlightDate=...`
+ * (PR #84 meeting polish batch). Also useful any time a meeting field that
+ * feeds buildMeetingDescription changes and every existing event needs to
+ * pick up the new payload.
  *
  * Idempotent — safe to re-run. Every run re-sends the same payload.
+ *
+ * Self-heal behavior on per-meeting errors:
+ *   - 404/410 → GCal event is gone (deleted manually or lost in a prior
+ *     sync). Clears gcal_event_id/etag/synced_at so the meeting is treated
+ *     as unsynced on next push (will create a fresh event).
+ *   - 412 → If-Match precondition failed (DB etag stale vs live event).
+ *     Clears only the etag so the next push sends an unconditional PUT.
+ *     The event linkage is preserved; re-run the script to finish.
+ *   - Anything else (network, auth, permission) → logged and counted as
+ *     `failed`. Re-run to retry.
  *
  * Throttled to 10 req/sec (well under Google Calendar's 100/sec hard quota)
  * so it won't trigger rate limiting even on large datasets.
@@ -27,12 +38,28 @@
  */
 import 'dotenv/config'
 import { isNotNull } from 'drizzle-orm'
+import { clearMeetingGCalFields, updateMeetingGCalFields } from '@/shared/dal/server/meetings/google-calendar'
 import { getSystemOwnerId } from '@/shared/dal/server/users/system'
 import { db } from '@/shared/db'
 import { meetings } from '@/shared/db/schema/meetings'
 import { schedulingService } from '@/shared/services/scheduling.service'
 
 const THROTTLE_MS = 100
+
+/**
+ * Extract the HTTP status code from a Google Calendar client error message.
+ * The client wraps all non-2xx responses as:
+ *   `Google Calendar ${op} failed (${status}): ${body}`
+ * So a simple regex recovers the code. Returns null if the error isn't one
+ * we can classify (e.g. network failure, auth error, unknown shape).
+ */
+function extractGcalStatus(err: unknown): number | null {
+  if (!(err instanceof Error)) {
+    return null
+  }
+  const match = err.message.match(/failed \((\d{3})\)/)
+  return match ? Number.parseInt(match[1]!, 10) : null
+}
 
 /**
  * The runtime DB client at src/shared/db/index.ts picks between DATABASE_URL
@@ -88,6 +115,8 @@ async function main() {
   }
 
   let success = 0
+  let orphanCleaned = 0
+  let etagCleared = 0
   let failed = 0
 
   for (const [index, m] of rows.entries()) {
@@ -96,12 +125,32 @@ async function main() {
       success += 1
     }
     catch (err) {
-      failed += 1
-      console.error(`[${index + 1}/${rows.length}] FAILED meeting ${m.id}:`, err instanceof Error ? err.message : err)
+      const status = extractGcalStatus(err)
+      if (status === 404 || status === 410) {
+        // Event no longer exists on Google — either deleted manually in the
+        // GCal UI or a previous sync cycle dropped it. DB's gcalEventId is
+        // pointing at a ghost. Clear the fields so future pushes treat this
+        // meeting as unsynced (create instead of update).
+        await clearMeetingGCalFields(m.id)
+        orphanCleaned += 1
+        console.warn(`[${index + 1}/${rows.length}] ORPHAN ${status} for meeting ${m.id} — cleared gcal_event_id/etag/synced_at`)
+      }
+      else if (status === 412) {
+        // If-Match precondition failed — DB etag is stale against the live
+        // event. Clearing just the etag lets the next push send an
+        // unconditional PUT that succeeds, without losing the event linkage.
+        await updateMeetingGCalFields(m.id, { gcalEtag: null })
+        etagCleared += 1
+        console.warn(`[${index + 1}/${rows.length}] STALE ETAG 412 for meeting ${m.id} — cleared etag; will succeed on next run`)
+      }
+      else {
+        failed += 1
+        console.error(`[${index + 1}/${rows.length}] FAILED meeting ${m.id}${status ? ` (HTTP ${status})` : ''}:`, err instanceof Error ? err.message : err)
+      }
     }
 
     if ((index + 1) % 10 === 0 || index + 1 === rows.length) {
-      console.log(`Progress: ${index + 1}/${rows.length}  (ok: ${success}, failed: ${failed})`)
+      console.log(`Progress: ${index + 1}/${rows.length}  (ok: ${success}, orphan: ${orphanCleaned}, etag: ${etagCleared}, failed: ${failed})`)
     }
 
     await new Promise(resolve => setTimeout(resolve, THROTTLE_MS))
@@ -109,12 +158,17 @@ async function main() {
 
   console.log('')
   console.log('--- RESULT ---')
-  console.log(`Success: ${success}`)
-  console.log(`Failed:  ${failed}`)
+  console.log(`Success:        ${success}`)
+  console.log(`Orphans cleaned: ${orphanCleaned}  (DB gcal_event_id pointed at a deleted GCal event — now NULL)`)
+  console.log(`Stale etags:     ${etagCleared}  (etag cleared — re-run to finish the update)`)
+  console.log(`Other failures:  ${failed}  (network/auth/permission — investigate logs above)`)
+
+  if (etagCleared > 0) {
+    console.log('')
+    console.log(`Re-run the script to finish ${etagCleared} stale-etag meeting(s). Their events still exist; they just need an unconditional PUT.`)
+  }
 
   if (failed > 0) {
-    console.log('')
-    console.log('Failed meetings were logged above. Re-run the script to retry — the updateEvent call is idempotent.')
     process.exit(1)
   }
 


### PR DESCRIPTION
## Summary
During your first prod run of \`rebuild:gcal\`, a handful of meetings failed because their \`gcal_event_id\` points at events that no longer exist on Google (deleted manually in GCal, or lost in a prior sync cycle). The original script logged them as generic failures and moved on, leaving the stale linkage in the DB.

This change classifies each per-meeting error by HTTP status and self-heals:

| Status | Meaning | Action |
|---|---|---|
| 404 / 410 | event is gone | clear \`gcal_event_id\`, \`gcal_etag\`, \`gcal_synced_at\` → next push creates fresh |
| 412 | \`If-Match\` precondition failed (DB etag stale) | clear just the etag → next push sends unconditional PUT |
| other | network / auth / permission | log + count as \`failed\` |

Summary counters now break down:
- **Success** — updated cleanly
- **Orphans cleaned** — gone-on-GCal meetings whose DB linkage got nulled
- **Stale etags** — recoverable on next run
- **Other failures** — actually broken, investigate

## How to use
```bash
pnpm rebuild:gcal -- --dry-run   # preview count
pnpm rebuild:gcal                # real run — heals in place
pnpm rebuild:gcal                # run again if any "Stale etags" were reported
```

## Self-Review
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm lint\` clean
- [x] Prod dry-run still reports 103 synced meetings

## Followup
Once this lands, re-run \`pnpm rebuild:gcal\` against prod. The orphans from the first run will be healed this time instead of flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)