### PR TITLE
fix(data-table): native touch scroll on mobile (#96)

### DIFF
--- a/src/shared/components/data-table/ui/data-table.tsx
+++ b/src/shared/components/data-table/ui/data-table.tsx
@@ -113,69 +113,6 @@ export function DataTable<TData extends { id: string }, TMeta = unknown>({
     }
   }, [])
 
-  // -- Mobile touch axis-lock ------------------------------------------------
-
-  const touchAxis = useRef<'x' | 'y' | null>(null)
-  const touchStart = useRef<{ x: number, y: number } | null>(null)
-  const scrollStart = useRef<{ left: number, top: number } | null>(null)
-  const AXIS_THRESHOLD = 8
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el || !isMobile) {
-      return
-    }
-
-    function onTouchStart(e: TouchEvent) {
-      const touch = e.touches[0]
-      if (!touch) {
-        return
-      }
-      touchAxis.current = null
-      touchStart.current = { x: touch.clientX, y: touch.clientY }
-      scrollStart.current = { left: el!.scrollLeft, top: el!.scrollTop }
-    }
-
-    function onTouchMove(e: TouchEvent) {
-      const touch = e.touches[0]
-      if (!touch || !touchStart.current || !scrollStart.current) {
-        return
-      }
-
-      const dx = touch.clientX - touchStart.current.x
-      const dy = touch.clientY - touchStart.current.y
-
-      if (!touchAxis.current) {
-        if (Math.abs(dx) < AXIS_THRESHOLD && Math.abs(dy) < AXIS_THRESHOLD) {
-          return
-        }
-        touchAxis.current = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y'
-      }
-
-      if (touchAxis.current === 'x') {
-        el!.scrollTop = scrollStart.current.top
-      }
-      else {
-        el!.scrollLeft = scrollStart.current.left
-      }
-    }
-
-    function onTouchEnd() {
-      touchAxis.current = null
-      touchStart.current = null
-      scrollStart.current = null
-    }
-
-    el.addEventListener('touchstart', onTouchStart, { passive: true })
-    el.addEventListener('touchmove', onTouchMove, { passive: true })
-    el.addEventListener('touchend', onTouchEnd, { passive: true })
-    return () => {
-      el.removeEventListener('touchstart', onTouchStart)
-      el.removeEventListener('touchmove', onTouchMove)
-      el.removeEventListener('touchend', onTouchEnd)
-    }
-  }, [isMobile])
-
   // -- Persist column sizes (debounced) -------------------------------------
 
   useEffect(() => {
@@ -341,7 +278,7 @@ export function DataTable<TData extends { id: string }, TMeta = unknown>({
           ref={scrollRef}
           onScroll={handleScroll}
           className={cn(
-            'grow min-h-0 overflow-auto overscroll-none',
+            'grow min-h-0 overflow-auto overscroll-none touch-pan-x touch-pan-y',
             '**:data-[slot=table-container]:overflow-visible',
             isAnyColumnResizing && 'cursor-col-resize select-none',
           )}


### PR DESCRIPTION
## Summary

The \`DataTable\` JS touch axis-lock (\`data-table.tsx:116-177\`) used \`passive: true\` listeners to record initial scroll position, then reverted the opposite-axis scroll after an 8px threshold on every touchmove. Because listeners were passive, native scroll had already been applied — so we were fighting every momentum frame, causing visible stutter and making mobile scroll unusable.

## Fix

- Delete the useEffect + \`touchAxis\`/\`touchStart\`/\`scrollStart\` refs
- Add \`touch-pan-x touch-pan-y\` CSS on the scroll container (explicit touch-action, documents intent — default behavior)

Modern mobile browsers handle single-dominant-axis scrolling natively via native momentum + \`touch-action\`. The JS override was actively breaking that.

## Changes

- \`src/shared/components/data-table/ui/data-table.tsx\` — 65 lines removed, 1 line changed

## Self-Review

- [x] \`pnpm tsc\` passes
- [x] \`pnpm lint\` passes
- [x] Diff is clean (pure deletion + one class addition)

## Test Plan

- [ ] Open any pipeline page on mobile viewport
- [ ] Scroll table vertically — smooth, no stutter
- [ ] Scroll table horizontally — smooth, no stutter  
- [ ] Quick diagonal flick — browser picks dominant axis, continues with momentum
- [ ] Release mid-gesture — momentum completes cleanly
- [ ] Same gesture session can scroll both axes (no permanent axis lock)

Closes #96