### PR TITLE
fix(data-table): respect single-axis scroll intent on mobile

### DIFF
--- a/src/shared/components/data-table/ui/data-table.tsx
+++ b/src/shared/components/data-table/ui/data-table.tsx
@@ -274,185 +274,196 @@ export function DataTable<TData extends { id: string }, TMeta = unknown>({
       )}
 
       <div className="grow min-h-0 flex flex-col rounded-xl border border-border/50 overflow-hidden">
-        <div
-          ref={scrollRef}
-          onScroll={handleScroll}
-          className={cn(
-            'grow min-h-0 overflow-auto overscroll-none touch-pan-x touch-pan-y',
-            '**:data-[slot=table-container]:overflow-visible',
-            isAnyColumnResizing && 'cursor-col-resize select-none',
-          )}
-        >
-          <Table className="table-fixed border-separate border-spacing-0" style={{ width: tableWidth }}>
-            <TableHeader className="sticky top-0 z-10 bg-background">
-              {table.getHeaderGroups().map(headerGroup => (
-                <TableRow key={headerGroup.id} className="hover:bg-transparent border-border/50">
-                  {headerGroup.headers.map((header, colIdx) => {
-                    const isColResizing = header.column.getIsResizing()
-                    const isFirstCol = colIdx === 0
-                    const isLastCol = colIdx === headerGroup.headers.length - 1
-                    const colWidth = header.getSize() + (isLastCol ? lastColExtra : 0)
+        {/*
+          Single-axis-per-gesture scroll:
+          - Outer wrapper: vertical scroll only (touch-pan-y)
+          - Inner wrapper: horizontal scroll only (touch-pan-x)
+          Browser locks to dominant axis at gesture start, preventing diagonal drift
+          on mobile while keeping native momentum. Inner uses overflow-y-clip (not
+          visible) to avoid CSS auto-normalization of mixed visible/auto, which
+          would otherwise trap the sticky header inside the horizontal container.
+        */}
+        <div className="grow min-h-0 overflow-y-auto overflow-x-hidden overscroll-none touch-pan-y">
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className={cn(
+              'overflow-x-auto overflow-y-clip touch-pan-x',
+              '**:data-[slot=table-container]:overflow-visible',
+              isAnyColumnResizing && 'cursor-col-resize select-none',
+            )}
+          >
+            <Table className="table-fixed border-separate border-spacing-0" style={{ width: tableWidth }}>
+              <TableHeader className="sticky top-0 z-10 bg-background">
+                {table.getHeaderGroups().map(headerGroup => (
+                  <TableRow key={headerGroup.id} className="hover:bg-transparent border-border/50">
+                    {headerGroup.headers.map((header, colIdx) => {
+                      const isColResizing = header.column.getIsResizing()
+                      const isFirstCol = colIdx === 0
+                      const isLastCol = colIdx === headerGroup.headers.length - 1
+                      const colWidth = header.getSize() + (isLastCol ? lastColExtra : 0)
 
-                    return (
-                      <TableHead
-                        key={header.id}
-                        className={cn(
-                          'group/th relative',
-                          CELL_BORDER,
-                          isFirstCol && isFrozen && cn(
-                            'sticky left-0 z-30 bg-background border-r border-border/50',
-                            'transition-shadow duration-200',
-                            showFrozenShadow && 'shadow-[4px_0_8px_0_rgba(0,0,0,0.3)]',
-                          ),
-                        )}
-                        style={{
-                          width: colWidth,
-                          ...(isFirstCol && isFrozen ? { borderRightStyle: 'dashed' as const } : undefined),
-                        }}
-                      >
-                        {/* Header content — first col gets a pin toggle */}
-                        {isFirstCol
-                          ? (
-                              <div className="flex items-center gap-1">
-                                <div className="min-w-0 flex-1">
-                                  {header.isPlaceholder
-                                    ? null
-                                    : flexRender(header.column.columnDef.header, header.getContext())}
+                      return (
+                        <TableHead
+                          key={header.id}
+                          className={cn(
+                            'group/th relative',
+                            CELL_BORDER,
+                            isFirstCol && isFrozen && cn(
+                              'sticky left-0 z-30 bg-background border-r border-border/50',
+                              'transition-shadow duration-200',
+                              showFrozenShadow && 'shadow-[4px_0_8px_0_rgba(0,0,0,0.3)]',
+                            ),
+                          )}
+                          style={{
+                            width: colWidth,
+                            ...(isFirstCol && isFrozen ? { borderRightStyle: 'dashed' as const } : undefined),
+                          }}
+                        >
+                          {/* Header content — first col gets a pin toggle */}
+                          {isFirstCol
+                            ? (
+                                <div className="flex items-center gap-1">
+                                  <div className="min-w-0 flex-1">
+                                    {header.isPlaceholder
+                                      ? null
+                                      : flexRender(header.column.columnDef.header, header.getContext())}
+                                  </div>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      toggleFrozen()
+                                    }}
+                                    className="shrink-0 cursor-pointer rounded p-0.5 hover:bg-muted"
+                                    title={isFrozen ? 'Unfreeze column' : 'Freeze column'}
+                                  >
+                                    <PinIcon
+                                      className={cn(
+                                        'h-3 w-3 rotate-45 transition-colors',
+                                        isFrozen
+                                          ? 'fill-foreground text-foreground'
+                                          : 'text-muted-foreground/50',
+                                      )}
+                                    />
+                                  </button>
                                 </div>
-                                <button
-                                  type="button"
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    toggleFrozen()
-                                  }}
-                                  className="shrink-0 cursor-pointer rounded p-0.5 hover:bg-muted"
-                                  title={isFrozen ? 'Unfreeze column' : 'Freeze column'}
-                                >
-                                  <PinIcon
-                                    className={cn(
-                                      'h-3 w-3 rotate-45 transition-colors',
-                                      isFrozen
-                                        ? 'fill-foreground text-foreground'
-                                        : 'text-muted-foreground/50',
-                                    )}
-                                  />
-                                </button>
-                              </div>
-                            )
-                          : (header.isPlaceholder
-                              ? null
-                              : flexRender(header.column.columnDef.header, header.getContext())
-                            )}
-
-                        {/* Resize handle — centred on the column's right edge */}
-                        {header.column.getCanResize() && !isLastCol && (
-                          <div
-                            onMouseDown={header.getResizeHandler()}
-                            onTouchStart={header.getResizeHandler()}
-                            onDoubleClick={() => header.column.resetSize()}
-                            className="absolute right-0 translate-x-1/2 top-0 z-30 w-2 cursor-col-resize select-none touch-none"
-                            style={{ height: isColResizing ? 9999 : '100%' }}
-                          >
-                            <div
-                              className={cn(
-                                'mx-auto h-full',
-                                isColResizing
-                                  ? 'w-0.5 border-l-2 border-dashed border-primary'
-                                  : 'w-px opacity-0 bg-border group-hover/th:opacity-100',
+                              )
+                            : (header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())
                               )}
-                            />
-                          </div>
-                        )}
 
-                        {/* Last column: resize handle on the RIGHT edge (inside the cell) */}
-                        {header.column.getCanResize() && isLastCol && (
-                          <div
-                            onMouseDown={header.getResizeHandler()}
-                            onTouchStart={header.getResizeHandler()}
-                            onDoubleClick={() => header.column.resetSize()}
-                            className="absolute right-0 top-0 z-30 w-1 cursor-col-resize select-none touch-none"
-                            style={{ height: isColResizing ? 9999 : '100%' }}
-                          >
+                          {/* Resize handle — centred on the column's right edge */}
+                          {header.column.getCanResize() && !isLastCol && (
                             <div
-                              className={cn(
-                                'ml-auto h-full',
-                                isColResizing
-                                  ? 'w-0.5 border-l-2 border-dashed border-primary'
-                                  : 'w-px opacity-0 bg-border group-hover/th:opacity-100',
-                              )}
-                            />
-                          </div>
-                        )}
-                      </TableHead>
-                    )
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-
-            <TableBody>
-              {table.getRowModel().rows.length > 0
-                ? table.getRowModel().rows.map((row) => {
-                    const rowProps: Record<string, unknown> = { [rowDataAttribute]: true }
-                    const customRowClass = getRowClassName?.(row.original)
-
-                    return (
-                      <TableRow
-                        key={row.id}
-                        className={`group cursor-pointer border-border/50${customRowClass ? ` ${customRowClass}` : ''}`}
-                        onClick={() => {
-                          if (onRowClick) {
-                            onRowClick(row.original)
-                          }
-                          else if (isMobile) {
-                            setActiveRowId(prev => prev === row.original.id ? null : row.original.id)
-                          }
-                        }}
-                        {...rowProps}
-                      >
-                        {row.getVisibleCells().map((cell, colIdx) => {
-                          if (colIdx === 0 && isFrozen) {
-                            return (
-                              <TableCell
-                                key={cell.id}
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onDoubleClick={() => header.column.resetSize()}
+                              className="absolute right-0 translate-x-1/2 top-0 z-30 w-2 cursor-col-resize select-none touch-none"
+                              style={{ height: isColResizing ? 9999 : '100%' }}
+                            >
+                              <div
                                 className={cn(
-                                  'sticky left-0 z-5 p-0 border-r border-border/50',
-                                  CELL_BORDER,
-                                  'transition-shadow duration-200',
-                                  showFrozenShadow && 'shadow-[4px_0_8px_0_rgba(0,0,0,0.3)]',
+                                  'mx-auto h-full',
+                                  isColResizing
+                                    ? 'w-0.5 border-l-2 border-dashed border-primary'
+                                    : 'w-px opacity-0 bg-border group-hover/th:opacity-100',
                                 )}
-                                style={{ borderRightStyle: 'dashed' }}
-                              >
-                                <div className="absolute inset-0 bg-background group-hover:bg-muted/50" />
-                                {customRowClass && <div className={cn('absolute inset-0', customRowClass)} />}
-                                <div className="relative p-2">
-                                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                </div>
+                              />
+                            </div>
+                          )}
+
+                          {/* Last column: resize handle on the RIGHT edge (inside the cell) */}
+                          {header.column.getCanResize() && isLastCol && (
+                            <div
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onDoubleClick={() => header.column.resetSize()}
+                              className="absolute right-0 top-0 z-30 w-1 cursor-col-resize select-none touch-none"
+                              style={{ height: isColResizing ? 9999 : '100%' }}
+                            >
+                              <div
+                                className={cn(
+                                  'ml-auto h-full',
+                                  isColResizing
+                                    ? 'w-0.5 border-l-2 border-dashed border-primary'
+                                    : 'w-px opacity-0 bg-border group-hover/th:opacity-100',
+                                )}
+                              />
+                            </div>
+                          )}
+                        </TableHead>
+                      )
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+
+              <TableBody>
+                {table.getRowModel().rows.length > 0
+                  ? table.getRowModel().rows.map((row) => {
+                      const rowProps: Record<string, unknown> = { [rowDataAttribute]: true }
+                      const customRowClass = getRowClassName?.(row.original)
+
+                      return (
+                        <TableRow
+                          key={row.id}
+                          className={`group cursor-pointer border-border/50${customRowClass ? ` ${customRowClass}` : ''}`}
+                          onClick={() => {
+                            if (onRowClick) {
+                              onRowClick(row.original)
+                            }
+                            else if (isMobile) {
+                              setActiveRowId(prev => prev === row.original.id ? null : row.original.id)
+                            }
+                          }}
+                          {...rowProps}
+                        >
+                          {row.getVisibleCells().map((cell, colIdx) => {
+                            if (colIdx === 0 && isFrozen) {
+                              return (
+                                <TableCell
+                                  key={cell.id}
+                                  className={cn(
+                                    'sticky left-0 z-5 p-0 border-r border-border/50',
+                                    CELL_BORDER,
+                                    'transition-shadow duration-200',
+                                    showFrozenShadow && 'shadow-[4px_0_8px_0_rgba(0,0,0,0.3)]',
+                                  )}
+                                  style={{ borderRightStyle: 'dashed' }}
+                                >
+                                  <div className="absolute inset-0 bg-background group-hover:bg-muted/50" />
+                                  {customRowClass && <div className={cn('absolute inset-0', customRowClass)} />}
+                                  <div className="relative p-2">
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                  </div>
+                                </TableCell>
+                              )
+                            }
+
+                            return (
+                              <TableCell key={cell.id} className={CELL_BORDER}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
                               </TableCell>
                             )
-                          }
-
-                          return (
-                            <TableCell key={cell.id} className={CELL_BORDER}>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                            </TableCell>
-                          )
-                        })}
+                          })}
+                        </TableRow>
+                      )
+                    })
+                  : (
+                      <TableRow>
+                        <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                          No
+                          {' '}
+                          {entityName}
+                          s match your filter.
+                        </TableCell>
                       </TableRow>
-                    )
-                  })
-                : (
-                    <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
-                        No
-                        {' '}
-                        {entityName}
-                        s match your filter.
-                      </TableCell>
-                    </TableRow>
-                  )}
-            </TableBody>
-          </Table>
+                    )}
+              </TableBody>
+            </Table>
+          </div>
         </div>
 
         <DataTablePagination table={table} />


### PR DESCRIPTION
## Summary
- Split scroll container into two nested wrappers: outer handles vertical (`touch-pan-y`), inner handles horizontal (`touch-pan-x`)
- `overflow-y-clip` on inner avoids CSS normalization that would otherwise trap sticky header
- Zero new JS — pure structural + CSS change

## Why
After PR #97 reverted the broken JS axis-lock, diagonal scrolling returned. Users lose the row/column they're reading when the table drifts on both axes during one gesture. User requirement: fix primarily with CSS, no JS counter-scrolling.

## How it works
Browser picks dominant touch-pan axis at gesture start and locks to it for the rest of the gesture. Vertical swipes hit outer's `touch-pan-y` and scroll outer; horizontal swipes hit inner's `touch-pan-x` and scroll inner. Diagonal swipes resolve to whichever component wins at gesture start.

`overflow-y-clip` is load-bearing: per CSS Overflow L3, mixing `visible` with `auto` on orthogonal axes normalizes both to `auto`, which would make inner a vertical-scroll container and trap `position: sticky top:0` on the table header. `clip` clips paint without creating a scroll container.

## Self-Review
- `pnpm tsc --noEmit` — clean
- `pnpm lint` — no new warnings

## Test Plan
- [ ] Mobile: horizontal-dominant swipe → horizontal scroll only, no vertical drift
- [ ] Mobile: vertical-dominant swipe → vertical scroll only, no horizontal drift
- [ ] Mobile: native momentum works on both axes
- [ ] Sticky header stays anchored during vertical scroll
- [ ] Frozen first-column shadow appears when horizontally scrolled
- [ ] Desktop mouse wheel / trackpad unchanged
- [ ] Column resize still works (drag handles)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)