### PR TITLE
fix(toast): respect iOS PWA safe-area-inset-top globally

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -370,6 +370,16 @@
   padding-bottom: env(safe-area-inset-bottom);
 }
 
+/* Sonner toasts in PWA mode                                      */
+/* Sonner sets --mobile-offset-top / --offset-top as inline styles, */
+/* so !important is required to push toasts below the status bar. */
+@media (display-mode: standalone) {
+  [data-sonner-toaster][data-y-position='top'] {
+    --mobile-offset-top: calc(16px + env(safe-area-inset-top)) !important;
+    --offset-top: calc(24px + env(safe-area-inset-top)) !important;
+  }
+}
+
 /* ── Dashboard sidebar nav hover ───────────────────────────────── */
 /* Soft tint on hover — no border, no shadow, just a gentle wash  */
 /* that hints at interactivity without mimicking the active state. */


### PR DESCRIPTION
## Summary
- CSS-only rule inside \`@media (display-mode: standalone)\` overrides Sonner's \`--offset-top\` / \`--mobile-offset-top\` to add \`env(safe-area-inset-top)\`
- Zero JS, zero per-toast config, applies to every current and future toast automatically
- No-op in regular browser tabs (\`display-mode\` is \`browser\`)

## Why
On iOS PWA, toasts at \`position="top-center"\` sat behind the status bar / Dynamic Island because the PWA viewport extends under the safe area. Without the browser chrome there's nothing to push them down.

## Why \`!important\`
Sonner sets \`--mobile-offset-top\` and \`--offset-top\` as **inline styles** on \`[data-sonner-toaster]\` (verified in \`node_modules/sonner/dist/index.mjs\`). A stylesheet rule can't override an inline style without \`!important\`. The alternative — passing a \`mobileOffset\` prop — would require runtime PWA detection and would also apply in browser tabs where Safari's viewport-fit=cover already returns non-zero \`env()\` values, double-pushing toasts.

## Self-Review
- \`pnpm tsc --noEmit\` — clean
- \`pnpm lint\` — no errors

## Test Plan
- [ ] iOS PWA (add to home screen): top-center toast clears the status bar / Dynamic Island
- [ ] iOS Safari tab: toast position unchanged (should still sit at normal 16px offset)
- [ ] Desktop browser: toast position unchanged (24px offset)
- [ ] Android PWA: toast clears status bar

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)