### PR TITLE
fix(intake): create owner participant row when meeting created via intake

### DIFF
--- a/src/shared/dal/server/meetings/participants.ts
+++ b/src/shared/dal/server/meetings/participants.ts
@@ -1,5 +1,6 @@
 import type { SQL } from 'drizzle-orm'
 import type { MeetingParticipantRole } from '@/shared/constants/enums'
+import type { DbOrTx } from '@/shared/db'
 import { and, asc, eq, exists, inArray, or } from 'drizzle-orm'
 import { db } from '@/shared/db'
 import { meetingParticipants, user } from '@/shared/db/schema'
@@ -183,8 +184,9 @@ export async function addParticipant(
   meetingId: string,
   userId: string,
   role: MeetingParticipantRole,
+  executor: DbOrTx = db,
 ): Promise<void> {
-  await db.insert(meetingParticipants).values({ meetingId, userId, role })
+  await executor.insert(meetingParticipants).values({ meetingId, userId, role })
 }
 
 export async function removeParticipant(meetingId: string, userId: string): Promise<void> {

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -17,4 +17,5 @@ const db = drizzle(pool, {
 })
 
 export type DB = typeof db
+export type DbOrTx = DB | Parameters<Parameters<DB['transaction']>[0]>[0]
 export { db }

--- a/src/trpc/routers/customers.router.ts
+++ b/src/trpc/routers/customers.router.ts
@@ -6,6 +6,7 @@ import z from 'zod'
 import env from '@/shared/config/server-env'
 import { intakeModes, leadSources } from '@/shared/constants/enums'
 import { getCustomer, getCustomerByNotionId, getCustomers, syncAllCustomers } from '@/shared/dal/server/customers/api'
+import { addParticipant } from '@/shared/dal/server/meetings/participants'
 import { db } from '@/shared/db'
 import { user } from '@/shared/db/schema/auth'
 import { customerNotes } from '@/shared/db/schema/customer-notes'
@@ -337,7 +338,15 @@ export const customersRouter = createTRPCRouter({
             })
             .returning()
 
-          meetingId = meeting?.id ?? null
+          if (!meeting) {
+            throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create meeting' })
+          }
+
+          // Mirror ownership in the participant junction table so every
+          // meeting has ≥1 owner participant (intake parity with meetings.create).
+          await addParticipant(meeting.id, ownerId, 'owner', tx)
+
+          meetingId = meeting.id
         }
 
         return { customerId: customer.id, meetingId }


### PR DESCRIPTION
## Summary
Customer+meeting intake path was setting \`meetings.ownerId\` but never inserting into \`meetingParticipants\` — every intake-created meeting had zero participants. Mirrors the fix to the agent-driven \`meetings.create\` pattern.

## Changes
- **DAL** (\`shared/dal/server/meetings/participants.ts\`): \`addParticipant\` now accepts an optional \`executor\` (\`DbOrTx\`), defaulting to \`db\`. Enables transactional callers without duplicating the insert.
- **Types** (\`shared/db/index.ts\`): new \`DbOrTx\` export alongside existing \`DB\`.
- **Intake path** (\`trpc/routers/customers.router.ts\`): \`addParticipant(meeting.id, ownerId, 'owner', tx)\` inside the transaction. Also tightened the meeting-insert null check to match the surrounding \`TRPCError\` style.

3 files, 14 insertions.

## Backfill
\`scripts/backfill-meeting-participants.ts\` already exists and is idempotent — run after deploy to repair existing orphan meetings.

## Self-Review
- \`pnpm tsc --noEmit\` — clean
- \`pnpm lint\` — no new errors

## Test Plan
- [ ] Authenticated agent creates customer+meeting via intake → meeting has 1 participant (agent) with role='owner'
- [ ] Unauthenticated intake → meeting has 1 participant (\`info@triprosremodeling.com\`) with role='owner'
- [ ] Existing \`meetings.create\` (agent-driven) still creates 1 owner participant
- [ ] Backfill script run in dev → orphans fixed
- [ ] GCal push includes the owner as attendee

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)