### PR TITLE
refactor(customers): drop legacy lead_source pgEnum column (FK migration phase 2)

### DIFF
--- a/scripts/migrate-notion-contacts.ts
+++ b/scripts/migrate-notion-contacts.ts
@@ -26,6 +26,7 @@ import * as schema from '../src/shared/db/schema'
 import { user } from '../src/shared/db/schema/auth'
 import { customerNotes } from '../src/shared/db/schema/customer-notes'
 import { customers } from '../src/shared/db/schema/customers'
+import { leadSourcesTable } from '../src/shared/db/schema/lead-sources'
 import { meetings } from '../src/shared/db/schema/meetings'
 import { notionClient } from '../src/shared/services/notion/client'
 import { notionDatabasesMeta } from '../src/shared/services/notion/constants/databases'
@@ -192,8 +193,15 @@ function buildTradeSelections(
 
 // ── Phase 1: Contacts ──────────────────────────────────────
 
+async function buildLeadSourceMap(): Promise<Map<string, string>> {
+  const rows = await db.select({ slug: leadSourcesTable.slug, id: leadSourcesTable.id }).from(leadSourcesTable)
+  return new Map(rows.map(r => [r.slug, r.id]))
+}
+
 async function migrateContacts(contactPages: PageObjectResponse[]) {
   console.log(`\n══ Phase 1: Contacts (${contactPages.length} found) ══\n`)
+
+  const leadSourceIdBySlug = await buildLeadSourceMap()
 
   let inserted = 0
   let skipped = 0
@@ -214,7 +222,8 @@ async function migrateContacts(contactPages: PageObjectResponse[]) {
         closedBy = closedByProp.rich_text.map(t => t.plain_text).join('') || null
       }
 
-      const { leadSource, leadType } = classifyContact(closedBy)
+      const { leadSource: leadSourceSlug, leadType } = classifyContact(closedBy)
+      const leadSourceId = leadSourceIdBySlug.get(leadSourceSlug) ?? null
 
       // Insert only — skip if customer already exists (PG is source of truth)
       const [row] = await db
@@ -228,7 +237,7 @@ async function migrateContacts(contactPages: PageObjectResponse[]) {
           city: contact.city || '',
           state: contact.state ?? undefined,
           zip: contact.zip || '',
-          leadSource,
+          leadSourceId,
           leadType,
         })
         .onConflictDoNothing({ target: customers.notionContactId })
@@ -282,7 +291,7 @@ async function migrateContacts(contactPages: PageObjectResponse[]) {
       }
 
       if (isNew) {
-        console.log(`Inserted: ${contact.name} (${leadSource})`)
+        console.log(`Inserted: ${contact.name} (${leadSourceSlug})`)
         inserted++
       }
       else {

--- a/src/shared/constants/enums/leads.ts
+++ b/src/shared/constants/enums/leads.ts
@@ -1,16 +1,3 @@
-/**
- * @deprecated Lead sources are now managed via the `lead_sources` table + `customers.leadSourceId` FK.
- * This const is kept only to keep the legacy `lead_source` pgEnum column alive during the dual-column
- * migration; it will be removed in the follow-up PR that drops the column.
- */
-export const leadSources = [
-  'telemarketing_leads_philippines',
-  'noy',
-  'quoteme',
-  'other',
-] as const
-export type LeadSource = (typeof leadSources)[number]
-
 export const leadTypes = [
   'appointment_set', // contact comes in with a meeting already scheduled
   'needs_confirmation', // lead captured, meeting not yet confirmed

--- a/src/shared/db/schema/customers.ts
+++ b/src/shared/db/schema/customers.ts
@@ -5,7 +5,7 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
 import { customerProfileSchema, financialProfileSchema, leadMetaSchema, propertyProfileSchema } from '@/shared/entities/customers/schemas'
 import { createdAt, id, updatedAt } from '../lib/schema-helpers'
 import { leadSourcesTable } from './lead-sources'
-import { customerPipelineEnum, leadSourceEnum, leadTypeEnum } from './meta'
+import { customerPipelineEnum, leadTypeEnum } from './meta'
 
 export const customers = pgTable('customers', {
   id,
@@ -24,8 +24,6 @@ export const customers = pgTable('customers', {
   customerProfileJSON: jsonb('customer_profile_json').$type<CustomerProfile>(),
   propertyProfileJSON: jsonb('property_profile_json').$type<PropertyProfile>(),
   financialProfileJSON: jsonb('financial_profile_json').$type<FinancialProfile>(),
-  /** @deprecated Use leadSourceId instead. Kept for backfill compatibility; removed in a follow-up migration once prod is fully on FK. */
-  leadSource: leadSourceEnum('lead_source'),
   leadSourceId: uuid('lead_source_id').references(() => leadSourcesTable.id, { onDelete: 'set null' }),
   leadType: leadTypeEnum('lead_type'),
   leadMetaJSON: jsonb('lead_meta_json').$type<LeadMeta>(),

--- a/src/shared/db/schema/meta.ts
+++ b/src/shared/db/schema/meta.ts
@@ -3,7 +3,6 @@ import {
   activityEntityTypes,
   activityTypes,
   customerPipelines,
-  leadSources,
   leadTypes,
   mediaPhases,
   meetingOutcomes,
@@ -51,6 +50,4 @@ export const meetingPipelineEnum = pgEnum('meeting_pipeline', meetingPipelines)
 export const projectStatusEnum = pgEnum('project_status', projectStatuses)
 
 // LEADS
-/** @deprecated Use `lead_source_id` FK on customers. Kept for dual-column migration; dropped in a follow-up. */
-export const leadSourceEnum = pgEnum('lead_source', leadSources)
 export const leadTypeEnum = pgEnum('lead_type', leadTypes)


### PR DESCRIPTION
## Summary

Phase 2 of the pgEnum → FK migration. Prod backfill verified (`0 orphans`), all runtime code uses `customers.lead_source_id`, so the legacy column is now unreferenced and safe to drop.

## Changes

**Schema:**
- Drop `customers.lead_source` pgEnum column
- Drop `leadSourceEnum` from `meta.ts`
- Drop `leadSources` const + `LeadSource` type from `enums/leads.ts`

**Scripts:**
- `migrate-notion-contacts.ts` now resolves classified slugs → `leadSourceId` via a pre-built slug→id map (one round-trip at startup, not per-row)

## Self-Review

- `pnpm tsc` clean
- `pnpm lint` clean (only pre-existing warnings)
- No runtime code referenced the old column — confirmed via grep

## Prod deploy sequence

After merge, run against prod:
```bash
pnpm db:push
```

This drops:
- `customers.lead_source` column
- `lead_source` pgEnum type

**Zero data loss** — all attribution was mirrored into `lead_source_id` by the dual-column PR (#123) and the backfill script, which prod already ran and verified.

## Test plan
- [ ] `pnpm db:push` drops column + enum without errors
- [ ] Public `/intake?source=<slug>` still creates customers
- [ ] `/dashboard/lead-sources` still shows accurate stats
- [ ] Existing customers retain their source attribution (via `lead_source_id`)

Follow-up to #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)