### PR TITLE
fix(intake): token-validated public URL (source + token query params)

### DIFF
--- a/src/app/(frontend)/intake/page.tsx
+++ b/src/app/(frontend)/intake/page.tsx
@@ -2,38 +2,42 @@ import { eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 import { IntakeFormView } from '@/features/intake/ui/views/intake-form-view'
+import { ROOTS } from '@/shared/config/roots'
 import { db } from '@/shared/db'
 import { leadSourcesTable } from '@/shared/db/schema/lead-sources'
 import { auth } from '@/shared/domains/auth/server'
 import { leadSourceFormConfigSchema } from '@/shared/entities/lead-sources/schemas'
 
 interface Props {
-  searchParams: Promise<{ source?: string }>
+  searchParams: Promise<{ source?: string, token?: string }>
 }
 
 export default async function PublicIntakePage({ searchParams }: Props) {
-  const { source } = await searchParams
+  const { source, token } = await searchParams
 
-  // No source param — check auth and redirect accordingly
-  if (!source) {
+  // Bare /intake — route super-admins to the Lead Sources admin page,
+  // everyone else to the home page. External URLs always include both
+  // `source` and `token`, so this branch only fires on accidental hits.
+  if (!source || !token) {
     const reqHeaders = await headers()
     const session = await auth.api.getSession({ headers: reqHeaders })
 
     if (session?.user.role === 'super-admin') {
-      redirect('/dashboard/intake')
+      redirect(ROOTS.dashboard.leadSources())
     }
 
     redirect('/')
   }
 
-  // Fetch lead source by slug
+  // Fetch lead source by slug, then verify token matches. 404 on any mismatch
+  // so attackers can't distinguish "slug doesn't exist" from "wrong token".
   const [row] = await db
     .select()
     .from(leadSourcesTable)
     .where(eq(leadSourcesTable.slug, source))
     .limit(1)
 
-  if (!row || !row.isActive) {
+  if (!row || !row.isActive || row.token !== token) {
     notFound()
   }
 

--- a/src/features/lead-sources-admin/ui/components/intake-url-card.tsx
+++ b/src/features/lead-sources-admin/ui/components/intake-url-card.tsx
@@ -11,10 +11,11 @@ import { useConfirm } from '@/shared/hooks/use-confirm'
 
 interface IntakeUrlCardProps {
   leadSourceId: string
+  slug: string
   token: string
 }
 
-export function IntakeUrlCard({ leadSourceId, token }: IntakeUrlCardProps) {
+export function IntakeUrlCard({ leadSourceId, slug, token }: IntakeUrlCardProps) {
   const [copied, setCopied] = useState(false)
   const { rotateToken } = useLeadSourceActions()
   const [RotateConfirmDialog, confirmRotate] = useConfirm({
@@ -23,8 +24,8 @@ export function IntakeUrlCard({ leadSourceId, token }: IntakeUrlCardProps) {
   })
 
   const url = typeof window !== 'undefined'
-    ? getIntakeUrl(token, window.location.origin)
-    : `…/intake/${token}`
+    ? getIntakeUrl(slug, token, window.location.origin)
+    : `…/intake?source=${slug}&token=${token}`
 
   const copy = () => {
     navigator.clipboard.writeText(url).then(

--- a/src/features/lead-sources-admin/ui/components/lead-source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-detail.tsx
@@ -64,7 +64,7 @@ export function LeadSourceDetail({ leadSourceId }: LeadSourceDetailProps) {
       </section>
 
       <section aria-label="Intake URL" className="flex flex-col gap-3 border-t border-border/40 pt-6">
-        <IntakeUrlCard leadSourceId={source.id} token={source.token} />
+        <IntakeUrlCard leadSourceId={source.id} slug={source.slug} token={source.token} />
       </section>
 
       <section aria-label="Form configuration" className="flex flex-col gap-4 border-t border-border/40 pt-6">

--- a/src/shared/entities/lead-sources/hooks/use-lead-source-action-configs.tsx
+++ b/src/shared/entities/lead-sources/hooks/use-lead-source-action-configs.tsx
@@ -15,6 +15,7 @@ import { useLeadSourceActions } from './use-lead-source-actions'
 
 interface LeadSourceEntity {
   id: string
+  slug: string
   token: string
   isActive: boolean
 }
@@ -45,7 +46,7 @@ export function useLeadSourceActionConfigs<T extends LeadSourceEntity>(
   })
 
   const copyIntakeUrl = useCallback((entity: T) => {
-    const url = getIntakeUrl(entity.token, window.location.origin)
+    const url = getIntakeUrl(entity.slug, entity.token, window.location.origin)
     navigator.clipboard.writeText(url).then(
       () => toast.success('Intake URL copied'),
       () => toast.error('Failed to copy'),
@@ -53,7 +54,7 @@ export function useLeadSourceActionConfigs<T extends LeadSourceEntity>(
   }, [])
 
   const previewIntake = useCallback((entity: T) => {
-    const url = getIntakeUrl(entity.token, window.location.origin)
+    const url = getIntakeUrl(entity.slug, entity.token, window.location.origin)
     window.open(url, '_blank', 'noopener,noreferrer')
   }, [])
 

--- a/src/shared/entities/lead-sources/lib/intake-url.ts
+++ b/src/shared/entities/lead-sources/lib/intake-url.ts
@@ -1,13 +1,12 @@
 /**
  * Canonical external intake URL for a lead source.
  *
- * Token-based path (`/intake/<token>`) — externally shared with third-party
- * lead providers. Never touches the dashboard; never requires auth. The token
- * is generated on lead-source creation and rotated only if leaked.
- *
- * Slug-based share (`/intake?source=<slug>`) is the legacy helper still used
- * by the `IntakeShareLinks` dropdown elsewhere in the app; do not use here.
+ * Both `source` (slug, readable in the URL) and `token` (unguessable secret)
+ * are required query params. The public route validates both, so guessing a
+ * slug alone is insufficient. Tokens never auto-rotate — only the manual
+ * "Rotate" action regenerates them, so URLs shared with partners stay stable.
  */
-export function getIntakeUrl(token: string, origin: string): string {
-  return `${origin}/intake/${token}`
+export function getIntakeUrl(slug: string, token: string, origin: string): string {
+  const params = new URLSearchParams({ source: slug, token })
+  return `${origin}/intake?${params.toString()}`
 }

--- a/src/trpc/routers/intake.router.ts
+++ b/src/trpc/routers/intake.router.ts
@@ -1,16 +1,11 @@
 import { TRPCError } from '@trpc/server'
 import { Ratelimit } from '@upstash/ratelimit'
 import { Redis } from '@upstash/redis'
-import { eq, inArray } from 'drizzle-orm'
 import z from 'zod'
 import env from '@/shared/config/server-env'
-import { db } from '@/shared/db'
-import { user } from '@/shared/db/schema/auth'
-import { leadSourcesTable } from '@/shared/db/schema/lead-sources'
-import { leadSourceFormConfigSchema } from '@/shared/entities/lead-sources/schemas'
 import { R2_BUCKETS } from '@/shared/services/r2/buckets'
 import { getPresignedUploadUrl } from '@/shared/services/r2/get-presigned-upload-url'
-import { agentProcedure, baseProcedure, createTRPCRouter } from '../init'
+import { baseProcedure, createTRPCRouter } from '../init'
 
 const redis = new Redis({
   url: env.UPSTASH_REDIS_REST_URL,
@@ -24,79 +19,6 @@ const uploadRatelimit = new Ratelimit({
 })
 
 export const intakeRouter = createTRPCRouter({
-  // Returns all active lead sources — super-admin only (used for share links)
-  getActiveSources: agentProcedure
-    .query(async ({ ctx }) => {
-      if (ctx.session.user.role !== 'super-admin') {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Super-admin access required.' })
-      }
-
-      return db
-        .select({
-          name: leadSourcesTable.name,
-          slug: leadSourcesTable.slug,
-        })
-        .from(leadSourcesTable)
-        .where(eq(leadSourcesTable.isActive, true))
-    }),
-
-  // Validates a lead source slug and returns form configuration
-  getBySlug: baseProcedure
-    .input(z.object({ slug: z.string().min(1) }))
-    .query(async ({ input }) => {
-      const [row] = await db
-        .select()
-        .from(leadSourcesTable)
-        .where(eq(leadSourcesTable.slug, input.slug))
-        .limit(1)
-
-      if (!row || !row.isActive) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'This intake form is no longer active.' })
-      }
-
-      const formConfig = leadSourceFormConfigSchema.parse(row.formConfigJSON)
-
-      return {
-        leadSourceSlug: row.slug,
-        leadSourceName: row.name,
-        formConfig,
-      }
-    }),
-
-  // Legacy — validates a lead source token (kept for backwards compatibility)
-  getByToken: baseProcedure
-    .input(z.object({ token: z.string().min(1) }))
-    .query(async ({ input }) => {
-      const [row] = await db
-        .select()
-        .from(leadSourcesTable)
-        .where(eq(leadSourcesTable.token, input.token))
-        .limit(1)
-
-      if (!row || !row.isActive) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'This link is no longer active.' })
-      }
-
-      const formConfig = leadSourceFormConfigSchema.parse(row.formConfigJSON)
-
-      return {
-        leadSourceSlug: row.slug,
-        leadSourceName: row.name,
-        formConfig,
-      }
-    }),
-
-  // Returns all internal users (agents + super-admins) for "Closed By" dropdown
-  getInternalUsers: baseProcedure
-    .query(async () => {
-      const internalUsers = await db
-        .select({ id: user.id, name: user.name })
-        .from(user)
-        .where(inArray(user.role, ['agent', 'super-admin']))
-
-      return internalUsers
-    }),
-
   // Returns a presigned R2 upload URL for a call recording
   getRecordingUploadUrl: baseProcedure
     .input(z.object({


### PR DESCRIPTION
## Summary

Fixes two latent bugs in the external intake URL flow and implements the static-but-unguessable URL architecture you asked for.

**Bug 1** — The admin-copyable URL pointed at `/intake/<token>` (path-based), but **no route exists at that path**. Every URL a partner received from the Lead Sources admin 404'd.

**Bug 2** — The public route at `/intake` only read `?source=<slug>` and **ignored the token entirely**. Anyone who could guess/enumerate a slug could submit against any active lead source.

## Fix

Canonical URL format: `/intake?source=<slug>&token=<token>` — both required, validated server-side. Wrong token → 404 (indistinguishable from "slug doesn't exist" so enumeration leaks nothing). Tokens never auto-rotate, so URLs stay stable for partners. Manual `Rotate` button stays for the leaked-URL scenario.

## Changes

**Contract:**
- `getIntakeUrl(slug, token, origin)` returns the canonical query-string URL
- `IntakeUrlCard` + `useLeadSourceActionConfigs` thread `slug` through (already available on the entity)

**Public route:**
- `/intake/page.tsx` now requires both `source` and `token` query params
- Fetches by slug, rejects if `token !== row.token`, returns 404 on any mismatch
- Bare `/intake` for a super-admin redirects to `/dashboard/lead-sources` (the old `/dashboard/intake` was deleted in #123)

**Cleanup:**
- Pruned four dead `intakeRouter` procedures with zero callers: `getActiveSources`, `getBySlug`, `getByToken`, `getInternalUsers`. The surviving `getInternalUsers` lives on `meetingsRouter` and is the one the participant picker actually uses.

## Self-Review

- `pnpm tsc` clean
- `pnpm lint` clean (only pre-existing warnings)
- No prod migration needed — this is pure code
- No data migration needed — existing `lead_sources.token` values work as-is

## Test plan
- [ ] Copy URL from an active lead source → opens the intake form correctly
- [ ] Tamper with the token in the copied URL → 404
- [ ] Tamper with the slug in the copied URL → 404
- [ ] Click Rotate → new URL generated → old URL 404s → new URL works
- [ ] Visit bare `/intake` as super-admin → redirected to Lead Sources admin page
- [ ] Visit bare `/intake` unauthenticated → redirected to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)