### PR TITLE
fix(lead-sources): memoize time-range + polish bundle (chips, skeleton, button, badges)

### DIFF
--- a/src/features/lead-sources-admin/constants/time-ranges.ts
+++ b/src/features/lead-sources-admin/constants/time-ranges.ts
@@ -19,9 +19,12 @@ export interface TimeRangeChip {
 
 export const DEFAULT_RANGE_KEY: TimeRangeKey = 'this-month'
 
+// Chronological order: shortest rolling window first, then this-month (which
+// is close to 30d but semantically distinct), then longer windows, then "all
+// time" as the terminator. Years append after this list.
 export const BASE_TIME_RANGE_CHIPS: readonly TimeRangeChip[] = [
-  { key: 'this-month', label: 'This month', kind: 'rolling', days: 30 },
   { key: '7d', label: '7d', kind: 'rolling', days: 7 },
+  { key: 'this-month', label: 'This month', kind: 'rolling', days: 30 },
   { key: '30d', label: '30d', kind: 'rolling', days: 30 },
   { key: '90d', label: '90d', kind: 'rolling', days: 90 },
   { key: 'all', label: 'All time', kind: 'all' },

--- a/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react'
 
 import { Input } from '@/shared/components/ui/input'
 import { Skeleton } from '@/shared/components/ui/skeleton'
+import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
 import { useTRPC } from '@/trpc/helpers'
 
 type AllCustomerRow = AppRouterOutputs['leadSourcesRouter']['getAllCustomers'][number]
@@ -88,7 +89,9 @@ function Row({ customer }: { customer: AllCustomerRow }) {
       <td className="px-3 py-2.5 text-xs text-muted-foreground">
         {customer.leadSourceName ?? 'Unknown'}
       </td>
-      <td className="px-3 py-2.5 text-xs text-muted-foreground">{customer.pipeline ?? '—'}</td>
+      <td className="px-3 py-2.5">
+        <CustomerPipelineBadge pipeline={customer.pipeline} />
+      </td>
       <td className="px-3 py-2.5 text-right text-xs tabular-nums text-muted-foreground">
         {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
           .format(new Date(customer.createdAt))}

--- a/src/features/lead-sources-admin/ui/components/all-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-detail.tsx
@@ -37,7 +37,11 @@ export function AllDetail({ sourceCount, onAddCustomer }: AllDetailProps) {
     [yearsQuery.data],
   )
   const activeChip = chips.find(c => c.key === rangeKey) ?? chips[0]!
-  const range = resolveTimeRange(activeChip)
+  // `resolveTimeRange` calls `new Date()` for rolling windows, so a naked
+  // call per render produces a ms-different `from`/`to` each tick — which
+  // becomes a new tRPC query key → refetch → re-render → new timestamp.
+  // Memoise on `activeChip.key` so the range is stable per chip selection.
+  const range = useMemo(() => resolveTimeRange(activeChip), [activeChip.key])
 
   const statsQuery = useQuery(
     trpc.leadSourcesRouter.getAggregateStats.queryOptions({

--- a/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react'
 
 import { Input } from '@/shared/components/ui/input'
 import { Skeleton } from '@/shared/components/ui/skeleton'
+import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
 import { useTRPC } from '@/trpc/helpers'
 
 type CustomerRow = AppRouterOutputs['leadSourcesRouter']['getCustomers'][number]
@@ -93,7 +94,9 @@ function CustomerTableRow({ customer }: { customer: CustomerRow }) {
     <tr className="hover:bg-muted/40 motion-safe:transition-colors">
       <td className="px-3 py-2.5 font-medium text-foreground">{customer.name}</td>
       <td className="px-3 py-2.5 text-muted-foreground">{customer.email ?? '—'}</td>
-      <td className="px-3 py-2.5 text-xs text-muted-foreground">{customer.pipeline ?? '—'}</td>
+      <td className="px-3 py-2.5">
+        <CustomerPipelineBadge pipeline={customer.pipeline} />
+      </td>
       <td className="px-3 py-2.5 text-right text-xs tabular-nums text-muted-foreground">
         {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
           .format(new Date(customer.createdAt))}

--- a/src/features/lead-sources-admin/ui/components/source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/source-detail.tsx
@@ -48,7 +48,11 @@ export function SourceDetail({ leadSourceId, onAddCustomer }: SourceDetailProps)
     [yearsQuery.data],
   )
   const activeChip = chips.find(c => c.key === rangeKey) ?? chips[0]!
-  const range = resolveTimeRange(activeChip)
+  // `resolveTimeRange` calls `new Date()` for rolling windows, so a naked
+  // call per render produces a ms-different `from`/`to` each tick — which
+  // becomes a new tRPC query key → refetch → re-render → new timestamp.
+  // Memoise on `activeChip.key` so the range is stable per chip selection.
+  const range = useMemo(() => resolveTimeRange(activeChip), [activeChip.key])
 
   const statsQuery = useQuery(
     trpc.leadSourcesRouter.getStats.queryOptions({

--- a/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
+++ b/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
@@ -38,30 +38,36 @@ export function LeadSourcesView() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="flex items-center justify-between gap-4 border-b border-border/40 px-6 py-4">
-        <div className="flex flex-col gap-1">
-          <h1 className="text-xl font-semibold text-foreground">Lead Sources</h1>
-          <p className="text-xs text-muted-foreground">
-            Performance tracking and intake configuration for every lead channel.
-          </p>
-        </div>
-        <Button onClick={() => setNewSheetOpen(true)} className="gap-1.5">
-          <PlusIcon className="size-4" />
-          New lead source
-        </Button>
+      <header className="flex flex-col gap-1 border-b border-border/40 px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Lead Sources</h1>
+        <p className="text-xs text-muted-foreground">
+          Performance tracking and intake configuration for every lead channel.
+        </p>
       </header>
 
       <div className="flex min-h-0 flex-1">
         <aside
           aria-label="Lead source list"
-          className="flex w-full min-w-0 flex-1 flex-col overflow-y-auto border-r border-border/40 px-4 py-4 sm:max-w-xs lg:max-w-sm"
+          className="flex w-full min-w-0 flex-1 flex-col border-r border-border/40 sm:max-w-xs lg:max-w-sm"
         >
-          <LeadSourceList
-            sources={sources}
-            isLoading={isLoading}
-            selectedId={selectedId}
-            onSelect={id => setSelectedId(id, { history: 'push' })}
-          />
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+            <LeadSourceList
+              sources={sources}
+              isLoading={isLoading}
+              selectedId={selectedId}
+              onSelect={id => setSelectedId(id, { history: 'push' })}
+            />
+          </div>
+          <div className="shrink-0 border-t border-border/40 p-3">
+            <Button
+              variant="outline"
+              onClick={() => setNewSheetOpen(true)}
+              className="w-full justify-start gap-2 border-dashed text-muted-foreground motion-safe:transition-colors hover:border-solid hover:bg-muted/60 hover:text-foreground"
+            >
+              <PlusIcon className="size-4" />
+              New lead source
+            </Button>
+          </div>
         </aside>
 
         <main className="flex min-w-0 flex-3 flex-col overflow-y-auto">

--- a/src/shared/components/ui/skeleton.tsx
+++ b/src/shared/components/ui/skeleton.tsx
@@ -4,7 +4,10 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn(
+        'rounded-md bg-muted/60 motion-safe:animate-pulse',
+        className,
+      )}
       {...props}
     />
   )

--- a/src/shared/entities/customers/components/customer-pipeline-badge.tsx
+++ b/src/shared/entities/customers/components/customer-pipeline-badge.tsx
@@ -1,0 +1,40 @@
+import type { CustomerPipeline } from '@/shared/constants/enums'
+
+import { Badge } from '@/shared/components/ui/badge'
+import { cn } from '@/shared/lib/utils'
+
+/**
+ * Colored badge for a customer's pipeline bucket. Colors align with the
+ * kanban stage palette (`badgeColorMap`) so a customer's status reads the
+ * same here as on the board.
+ */
+interface CustomerPipelineBadgeProps {
+  pipeline: CustomerPipeline | null | undefined
+  className?: string
+}
+
+const PIPELINE_CLASSES: Record<CustomerPipeline, string> = {
+  active: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  rehash: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  dead: 'bg-slate-500/10 text-slate-700 dark:text-slate-400',
+}
+
+const PIPELINE_LABELS: Record<CustomerPipeline, string> = {
+  active: 'Active',
+  rehash: 'Rehash',
+  dead: 'Dead',
+}
+
+export function CustomerPipelineBadge({ pipeline, className }: CustomerPipelineBadgeProps) {
+  if (!pipeline) {
+    return <span className="text-xs text-muted-foreground">—</span>
+  }
+  return (
+    <Badge
+      variant="secondary"
+      className={cn('border-transparent', PIPELINE_CLASSES[pipeline], className)}
+    >
+      {PIPELINE_LABELS[pipeline]}
+    </Badge>
+  )
+}


### PR DESCRIPTION
## Summary

One critical fix + four polish items bundled together.

### Critical fix — infinite refetch loop

The \`resolveTimeRange()\` helper for rolling windows calls \`new Date()\`, so calling it unmemoised in render produced a ms-different \`from\`/\`to\` on every tick. That's a fresh tRPC query key each render → refetch → re-render → new timestamp → infinite loop.

Visible in the network tab as \`getAggregateStats\` firing every ~150ms with incrementing timestamps. Same bug was latent in the original \`PerformanceStrip\` against \`getStats\`; moving resolution up to the parent components in #126 surfaced it as a clear symptom.

Fix: both \`AllDetail\` and \`SourceDetail\` now \`useMemo(() => resolveTimeRange(activeChip), [activeChip.key])\`. Timestamp captured once per chip selection, stable across renders.

### Polish

- **Time-range chips** reorder to chronological scan: \`7d → This month → 30d → 90d → All time\`. Year chips still appended by \`buildChipsWithYears\`.
- **Skeleton primitive** drops \`bg-accent\` (primary-leaning in this theme) for \`bg-muted/60\`, and prefixes \`animate-pulse\` with \`motion-safe:\` to respect reduced-motion.
- **"New lead source" button** moves out of the page header and pins to the bottom of the left list as a dashed-outline "add more" affordance — reads as part of the list's compositional rhythm.
- **\`CustomerPipelineBadge\`** (new, shared) renders \`active / rehash / dead\` with semantic color tokens (green / amber / slate). Wired into both customers tables in place of plain-text pipeline columns.

## Self-Review

- \`pnpm tsc\` clean
- \`pnpm lint\` clean
- Memoization fix verified against the grep: only two callsites of \`resolveTimeRange\` in the repo, both memoized.
- Hard rules audited: semantic color tokens, \`motion-safe:\` prefix on all transitions, no primary-color overload, no banned patterns.

## Test plan
- [ ] Open \`/dashboard/lead-sources\` → network tab shows \`getAggregateStats\` fired **once**, not on every tick
- [ ] Change time-range chip → single additional fetch with new from/to
- [ ] Chip order reads 7d → This month → 30d → 90d → years → All time
- [ ] Skeletons appear in muted tone, not primary-tinted
- [ ] "New lead source" button sits at the bottom of the left list
- [ ] Customer rows show colored pipeline badges (green/amber/slate)

## Known out-of-scope
The user flagged an intermittent better-auth recursion error ("random, often self-corrects upon refresh"). Unrelated to this PR — deserves its own investigation post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)