### PR TITLE
feat(lead-sources): lift time range to page-level URL state

### DIFF
--- a/src/features/lead-sources-admin/ui/components/all-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-detail.tsx
@@ -1,47 +1,29 @@
 'use client'
 
-import type { TimeRangeKey } from '@/features/lead-sources-admin/constants/time-ranges'
+import type { TimeRangeChip } from '@/features/lead-sources-admin/constants/time-ranges'
 
 import { useQuery } from '@tanstack/react-query'
 import { PlusIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
 
-import { BASE_TIME_RANGE_CHIPS, DEFAULT_RANGE_KEY } from '@/features/lead-sources-admin/constants/time-ranges'
-import { buildChipsWithYears, resolveTimeRange } from '@/features/lead-sources-admin/lib/resolve-time-range'
 import { AllCustomersSection } from '@/features/lead-sources-admin/ui/components/all-customers-section'
 import { PerformanceStrip } from '@/features/lead-sources-admin/ui/components/performance-strip'
-import { TimeRangeChips } from '@/features/lead-sources-admin/ui/components/time-range-chips'
 import { Button } from '@/shared/components/ui/button'
 import { useTRPC } from '@/trpc/helpers'
 
 interface AllDetailProps {
   sourceCount: number
+  activeChip: TimeRangeChip
+  range: { from?: string, to?: string }
   onAddCustomer: () => void
 }
 
 /**
- * Aggregate pane shown when the "All" pseudo-row is selected. No tabs — the
- * primary job here is (a) glance at total pipeline health across every source
- * and (b) log an ad-hoc manual customer that wasn't tied to a campaign.
+ * Aggregate pane shown when the "All" pseudo-row is selected. Receives the
+ * globally-selected time range from the view so the performance strip reacts
+ * to the same chip as the left-col stats.
  */
-export function AllDetail({ sourceCount, onAddCustomer }: AllDetailProps) {
+export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: AllDetailProps) {
   const trpc = useTRPC()
-  const [rangeKey, setRangeKey] = useState<TimeRangeKey>(DEFAULT_RANGE_KEY)
-
-  const yearsQuery = useQuery(
-    trpc.leadSourcesRouter.getYearsWithActivity.queryOptions(),
-  )
-
-  const chips = useMemo(
-    () => buildChipsWithYears(BASE_TIME_RANGE_CHIPS, yearsQuery.data ?? []),
-    [yearsQuery.data],
-  )
-  const activeChip = chips.find(c => c.key === rangeKey) ?? chips[0]!
-  // `resolveTimeRange` calls `new Date()` for rolling windows, so a naked
-  // call per render produces a ms-different `from`/`to` each tick — which
-  // becomes a new tRPC query key → refetch → re-render → new timestamp.
-  // Memoise on `activeChip.key` so the range is stable per chip selection.
-  const range = useMemo(() => resolveTimeRange(activeChip), [activeChip.key])
 
   const statsQuery = useQuery(
     trpc.leadSourcesRouter.getAggregateStats.queryOptions({
@@ -66,12 +48,9 @@ export function AllDetail({ sourceCount, onAddCustomer }: AllDetailProps) {
       </header>
 
       <section aria-label="Aggregate performance" className="flex flex-col gap-4 border-t border-border/40 pt-6">
-        <div className="flex items-center justify-between gap-4">
-          <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-            Performance
-          </h3>
-          <TimeRangeChips chips={chips} value={activeChip.key} onChange={setRangeKey} />
-        </div>
+        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Performance
+        </h3>
         <PerformanceStrip
           stats={statsQuery.data}
           chip={activeChip}

--- a/src/features/lead-sources-admin/ui/components/lead-source-list.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-list.tsx
@@ -19,9 +19,11 @@ interface LeadSourceListProps {
   /** `selectedId` may be a uuid or the literal `'all'`. */
   selectedId: string | null
   onSelect: (id: string) => void
+  /** Label for the range-scoped stat column (mirrors the global time picker). */
+  rangeLabel: string
 }
 
-export function LeadSourceList({ sources, isLoading, selectedId, onSelect }: LeadSourceListProps) {
+export function LeadSourceList({ sources, isLoading, selectedId, onSelect, rangeLabel }: LeadSourceListProps) {
   const [search, setSearch] = useState('')
 
   const filtered = useMemo(() => {
@@ -37,8 +39,8 @@ export function LeadSourceList({ sources, isLoading, selectedId, onSelect }: Lea
     )
   }, [sources, search])
 
-  const allTotal = useMemo(
-    () => (sources ?? []).reduce((acc, s) => acc + (s.totalLeads ?? 0), 0),
+  const allInRange = useMemo(
+    () => (sources ?? []).reduce((acc, s) => acc + (s.leadsInRange ?? 0), 0),
     [sources],
   )
 
@@ -63,7 +65,8 @@ export function LeadSourceList({ sources, isLoading, selectedId, onSelect }: Lea
       <nav aria-label="Lead sources" className="flex flex-col gap-1">
         {/* Pinned "All" pseudo-row — always at top, not filtered, not searchable. */}
         <AllRow
-          total={allTotal}
+          total={allInRange}
+          rangeLabel={rangeLabel}
           isSelected={isAllSelected}
           onSelect={() => onSelect(ALL_PSEUDO_ID)}
           disabled={isLoading}
@@ -85,8 +88,8 @@ export function LeadSourceList({ sources, isLoading, selectedId, onSelect }: Lea
                   <LeadSourceOverviewCard.Indicator />
                   <LeadSourceOverviewCard.Identity />
                   <LeadSourceOverviewCard.Stat
-                    value={source.leadsThisMonth}
-                    label="This month"
+                    value={source.leadsInRange}
+                    label={rangeLabel}
                   />
                 </LeadSourceOverviewCard>
               ))}
@@ -97,12 +100,13 @@ export function LeadSourceList({ sources, isLoading, selectedId, onSelect }: Lea
 
 interface AllRowProps {
   total: number
+  rangeLabel: string
   isSelected: boolean
   onSelect: () => void
   disabled: boolean
 }
 
-function AllRow({ total, isSelected, onSelect, disabled }: AllRowProps) {
+function AllRow({ total, rangeLabel, isSelected, onSelect, disabled }: AllRowProps) {
   return (
     <button
       type="button"
@@ -124,7 +128,7 @@ function AllRow({ total, isSelected, onSelect, disabled }: AllRowProps) {
       </span>
       <span className="flex flex-col items-end gap-px tabular-nums">
         <span className="text-sm font-semibold text-foreground">{total}</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Total</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{rangeLabel}</span>
       </span>
     </button>
   )

--- a/src/features/lead-sources-admin/ui/components/source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/source-detail.tsx
@@ -1,20 +1,16 @@
 'use client'
 
-import type { TimeRangeKey } from '@/features/lead-sources-admin/constants/time-ranges'
+import type { TimeRangeChip } from '@/features/lead-sources-admin/constants/time-ranges'
 
 import { useQuery } from '@tanstack/react-query'
 import { PlusIcon } from 'lucide-react'
 import { parseAsStringEnum, useQueryState } from 'nuqs'
-import { useMemo, useState } from 'react'
 
-import { BASE_TIME_RANGE_CHIPS, DEFAULT_RANGE_KEY } from '@/features/lead-sources-admin/constants/time-ranges'
-import { buildChipsWithYears, resolveTimeRange } from '@/features/lead-sources-admin/lib/resolve-time-range'
 import { FormConfigEditor } from '@/features/lead-sources-admin/ui/components/form-config-editor'
 import { IntakeUrlCard } from '@/features/lead-sources-admin/ui/components/intake-url-card'
 import { LeadSourceCustomersSection } from '@/features/lead-sources-admin/ui/components/lead-source-customers-section'
 import { LeadSourceDetailHeader } from '@/features/lead-sources-admin/ui/components/lead-source-detail-header'
 import { PerformanceStrip } from '@/features/lead-sources-admin/ui/components/performance-strip'
-import { TimeRangeChips } from '@/features/lead-sources-admin/ui/components/time-range-chips'
 import { Button } from '@/shared/components/ui/button'
 import { Skeleton } from '@/shared/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs'
@@ -25,12 +21,13 @@ type SourceTab = (typeof SOURCE_TABS)[number]
 
 interface SourceDetailProps {
   leadSourceId: string
+  activeChip: TimeRangeChip
+  range: { from?: string, to?: string }
   onAddCustomer: (source: { slug: string, name: string }) => void
 }
 
-export function SourceDetail({ leadSourceId, onAddCustomer }: SourceDetailProps) {
+export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }: SourceDetailProps) {
   const trpc = useTRPC()
-  const [rangeKey, setRangeKey] = useState<TimeRangeKey>(DEFAULT_RANGE_KEY)
   const [tab, setTab] = useQueryState(
     'tab',
     parseAsStringEnum([...SOURCE_TABS]).withDefault('overview'),
@@ -39,20 +36,6 @@ export function SourceDetail({ leadSourceId, onAddCustomer }: SourceDetailProps)
   const sourceQuery = useQuery(
     trpc.leadSourcesRouter.getById.queryOptions({ id: leadSourceId }),
   )
-  const yearsQuery = useQuery(
-    trpc.leadSourcesRouter.getYearsWithActivity.queryOptions(),
-  )
-
-  const chips = useMemo(
-    () => buildChipsWithYears(BASE_TIME_RANGE_CHIPS, yearsQuery.data ?? []),
-    [yearsQuery.data],
-  )
-  const activeChip = chips.find(c => c.key === rangeKey) ?? chips[0]!
-  // `resolveTimeRange` calls `new Date()` for rolling windows, so a naked
-  // call per render produces a ms-different `from`/`to` each tick — which
-  // becomes a new tRPC query key → refetch → re-render → new timestamp.
-  // Memoise on `activeChip.key` so the range is stable per chip selection.
-  const range = useMemo(() => resolveTimeRange(activeChip), [activeChip.key])
 
   const statsQuery = useQuery(
     trpc.leadSourcesRouter.getStats.queryOptions({
@@ -86,12 +69,9 @@ export function SourceDetail({ leadSourceId, onAddCustomer }: SourceDetailProps)
 
         <TabsContent value="overview" className="flex flex-col gap-8 pt-4">
           <section aria-label="Performance" className="flex flex-col gap-4">
-            <div className="flex items-center justify-between gap-4">
-              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                Performance
-              </h3>
-              <TimeRangeChips chips={chips} value={activeChip.key} onChange={setRangeKey} />
-            </div>
+            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Performance
+            </h3>
             <PerformanceStrip
               stats={statsQuery.data}
               chip={activeChip}

--- a/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
+++ b/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
@@ -1,21 +1,25 @@
 'use client'
 
+import type { TimeRangeKey } from '@/features/lead-sources-admin/constants/time-ranges'
+
 import { useQuery } from '@tanstack/react-query'
 import { PlusIcon, RadioTowerIcon } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { ALL_PSEUDO_ID } from '@/features/lead-sources-admin/constants/pseudo-ids'
+import { BASE_TIME_RANGE_CHIPS, DEFAULT_RANGE_KEY } from '@/features/lead-sources-admin/constants/time-ranges'
+import { buildChipsWithYears, resolveTimeRange } from '@/features/lead-sources-admin/lib/resolve-time-range'
 import { AddCustomerSheet } from '@/features/lead-sources-admin/ui/components/add-customer-sheet'
 import { AllDetail } from '@/features/lead-sources-admin/ui/components/all-detail'
 import { LeadSourceList } from '@/features/lead-sources-admin/ui/components/lead-source-list'
 import { NewLeadSourceSheet } from '@/features/lead-sources-admin/ui/components/new-lead-source-sheet'
 import { SourceDetail } from '@/features/lead-sources-admin/ui/components/source-detail'
+import { TimeRangeChips } from '@/features/lead-sources-admin/ui/components/time-range-chips'
 import { Button } from '@/shared/components/ui/button'
 import { useTRPC } from '@/trpc/helpers'
 
 interface AddSheetState {
-  /** Lead source slug to attribute the new customer to; undefined → `manual`. */
   slug?: string
   name?: string
 }
@@ -26,11 +30,32 @@ export function LeadSourcesView() {
     'id',
     parseAsString.withDefault(ALL_PSEUDO_ID),
   )
+  const [rangeKey, setRangeKey] = useQueryState(
+    'range',
+    parseAsString.withDefault(DEFAULT_RANGE_KEY),
+  )
   const [newSheetOpen, setNewSheetOpen] = useState(false)
   const [addSheetState, setAddSheetState] = useState<AddSheetState | null>(null)
 
+  // Global time range — one source of truth. Every pane + the left-col
+  // stats consume the same `activeChip`. `resolveTimeRange` is memoised on
+  // `activeChip.key` so rolling windows don't reshuffle timestamps each
+  // render (see PR #127 for the infinite-refetch fix).
+  const yearsQuery = useQuery(
+    trpc.leadSourcesRouter.getYearsWithActivity.queryOptions(),
+  )
+  const chips = useMemo(
+    () => buildChipsWithYears(BASE_TIME_RANGE_CHIPS, yearsQuery.data ?? []),
+    [yearsQuery.data],
+  )
+  const activeChip = chips.find(c => c.key === rangeKey) ?? chips[0]!
+  const range = useMemo(() => resolveTimeRange(activeChip), [activeChip.key])
+
   const { data: sources, isLoading } = useQuery(
-    trpc.leadSourcesRouter.list.queryOptions(),
+    trpc.leadSourcesRouter.list.queryOptions({
+      from: range.from,
+      to: range.to,
+    }),
   )
 
   const hasSources = (sources?.length ?? 0) > 0
@@ -45,6 +70,17 @@ export function LeadSourcesView() {
         </p>
       </header>
 
+      <div className="flex items-center justify-between gap-4 border-b border-border/40 px-6 py-3">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Time range
+        </span>
+        <TimeRangeChips
+          chips={chips}
+          value={activeChip.key}
+          onChange={k => setRangeKey(k as TimeRangeKey, { history: 'replace' })}
+        />
+      </div>
+
       <div className="flex min-h-0 flex-1">
         <aside
           aria-label="Lead source list"
@@ -56,6 +92,7 @@ export function LeadSourcesView() {
               isLoading={isLoading}
               selectedId={selectedId}
               onSelect={id => setSelectedId(id, { history: 'push' })}
+              rangeLabel={activeChip.label}
             />
           </div>
           <div className="shrink-0 border-t border-border/40 p-3">
@@ -77,12 +114,16 @@ export function LeadSourcesView() {
               ? (
                   <AllDetail
                     sourceCount={sources?.length ?? 0}
+                    activeChip={activeChip}
+                    range={range}
                     onAddCustomer={() => setAddSheetState({})}
                   />
                 )
               : (
                   <SourceDetail
                     leadSourceId={selectedId}
+                    activeChip={activeChip}
+                    range={range}
                     onAddCustomer={src => setAddSheetState(src)}
                   />
                 )}

--- a/src/shared/entities/lead-sources/components/overview-card.tsx
+++ b/src/shared/entities/lead-sources/components/overview-card.tsx
@@ -14,7 +14,7 @@ export interface LeadSourceOverviewCardSource {
   slug: string
   isActive: boolean
   totalLeads?: number
-  leadsThisMonth?: number
+  leadsInRange?: number
 }
 
 interface ContextValue {

--- a/src/trpc/routers/lead-sources.router.ts
+++ b/src/trpc/routers/lead-sources.router.ts
@@ -77,11 +77,25 @@ const updateInput = z.object({
 
 export const leadSourcesRouter = createTRPCRouter({
   // List of all lead sources with compact stats for the left-pane picker.
+  // The optional time range scopes `leadsInRange` so the list reacts to the
+  // global time picker in the page header. When absent, `leadsInRange`
+  // degrades to `totalLeads`.
   list: agentProcedure
-    .input(z.object({ includeInactive: z.boolean().default(true) }).optional())
+    .input(z.object({
+      includeInactive: z.boolean().default(true),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+    }).optional())
     .query(async ({ ctx, input }) => {
       requireSuperAdmin(ctx.session.user.role)
       const includeInactive = input?.includeInactive ?? true
+      const from = input?.from
+      const to = input?.to
+
+      // Build the range predicate as raw SQL fragments that plug into the
+      // correlated subquery below. NULL bounds simply drop their clause.
+      const fromClause = from ? sql`AND ${customers.createdAt} >= ${from}` : sql``
+      const toClause = to ? sql`AND ${customers.createdAt} <= ${to}` : sql``
 
       const rows = await db
         .select({
@@ -96,10 +110,11 @@ export const leadSourcesRouter = createTRPCRouter({
             SELECT COUNT(*)::int FROM ${customers}
             WHERE ${customers.leadSourceId} = ${leadSourcesTable.id}
           )`,
-          leadsThisMonth: sql<number>`(
+          leadsInRange: sql<number>`(
             SELECT COUNT(*)::int FROM ${customers}
             WHERE ${customers.leadSourceId} = ${leadSourcesTable.id}
-              AND ${customers.createdAt} >= date_trunc('month', NOW())
+              ${fromClause}
+              ${toClause}
           )`,
         })
         .from(leadSourcesTable)


### PR DESCRIPTION
## Summary

Addresses your Addition #2: make the time picker global so the entire Lead Sources dashboard reacts atomically.

Before: the chips lived inside each detail pane with local state, so the left-col row stats stayed frozen on a hardcoded \"this month\" while the detail pane reacted independently. Picking a year felt like flipping between disconnected dashboards.

After: one picker in the page toolbar, persisted to \`?range=<chipKey>\`. Every consumer — aggregate pane, per-source pane, left-col row stats — reads from the same active chip.

## Changes

**Router:**
- \`list\` gains optional \`from\`/\`to\` inputs
- \`leadsThisMonth\` → \`leadsInRange\`; the correlated subquery builds its predicate from the inputs (NULL bounds drop their clause)

**View:**
- \`?range=<chipKey>\` URL state via nuqs (default \`this-month\`)
- \`TimeRangeChips\` rendered in a toolbar row below the page header, right-aligned opposite a \"Time range\" label
- Resolved \`range\` memoised on \`activeChip.key\` (preserves the #127 fix)
- Passes \`activeChip\` + \`range\` down to both detail panes + the list

**Detail panes:**
- \`AllDetail\` and \`SourceDetail\` drop local range state + the years/chips queries (all moved up to the view). They're pure consumers now.
- Per-performance-section chip UI removed; the global toolbar is the one control.

**List:**
- \`LeadSourceOverviewCard.Stat\` label reads \`activeChip.label\` per row — rows read \`"7d"\`, \`"This month"\`, \`"2025"\`, \`"All time"\` as you toggle
- \`AllRow\` mirrors the same label
- Aggregate total in the \`All\` pseudo-row sums \`leadsInRange\` across visible sources

## Self-Review

- \`pnpm tsc\` clean
- \`pnpm lint\` clean
- Memoisation invariant preserved: the infinite-loop fix from #127 carries through because the single \`useMemo\` now lives at the view level
- No extra fetches: left-col already refetched on range change (via \`list\` query key), and each detail pane fetches its own range-scoped stats — same network shape as before, just coordinated

## Test plan
- [ ] Pick \`7d\` → left-col stats show \`7d\` label and 7-day counts; right pane performance strip shows the same range
- [ ] Pick a year chip → left-col labels read the year; right pane stats match
- [ ] Pick \`All time\` → left-col shows all-time counts under the \`All time\` label; matches \`totalLeads\`
- [ ] Reload the page with \`?range=7d\` → picker restores correctly
- [ ] Switch between \`All\` row and a source → same range persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)