### PR TITLE
fix(lead-sources): leadsInRange=0 on All time + editable createdAt

### DIFF
--- a/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
@@ -2,12 +2,16 @@
 
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
 
+import { DateTimePicker } from '@/shared/components/date-time-picker'
 import { Input } from '@/shared/components/ui/input'
 import { Skeleton } from '@/shared/components/ui/skeleton'
+import { useInvalidation } from '@/shared/dal/client/use-invalidation'
 import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
+import { formatDateCell } from '@/shared/lib/formatters'
 import { useTRPC } from '@/trpc/helpers'
 
 type AllCustomerRow = AppRouterOutputs['leadSourcesRouter']['getAllCustomers'][number]
@@ -19,12 +23,24 @@ type AllCustomerRow = AppRouterOutputs['leadSourcesRouter']['getAllCustomers'][n
  */
 export function AllCustomersSection() {
   const trpc = useTRPC()
+  const { invalidateCustomer, invalidateLeadSource } = useInvalidation()
   const [search, setSearch] = useState('')
 
   const { data, isLoading } = useQuery(
     trpc.leadSourcesRouter.getAllCustomers.queryOptions({
       search: search.trim() || undefined,
       limit: 100,
+    }),
+  )
+
+  const updateCreatedAt = useMutation(
+    trpc.customersRouter.updateCreatedAt.mutationOptions({
+      onSuccess: () => {
+        toast.success('Created date updated')
+        invalidateCustomer()
+        invalidateLeadSource()
+      },
+      onError: err => toast.error(err.message),
     }),
   )
 
@@ -72,7 +88,15 @@ export function AllCustomersSection() {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-border/40">
-                    {data?.map(c => <Row key={c.id} customer={c} />)}
+                    {data?.map(c => (
+                      <Row
+                        key={c.id}
+                        customer={c}
+                        onUpdateCreatedAt={(date) => {
+                          updateCreatedAt.mutate({ customerId: c.id, createdAt: date.toISOString() })
+                        }}
+                      />
+                    ))}
                   </tbody>
                 </table>
               </div>
@@ -81,7 +105,13 @@ export function AllCustomersSection() {
   )
 }
 
-function Row({ customer }: { customer: AllCustomerRow }) {
+interface RowProps {
+  customer: AllCustomerRow
+  onUpdateCreatedAt: (date: Date) => void
+}
+
+function Row({ customer, onUpdateCreatedAt }: RowProps) {
+  const { relative, dayAtTime } = formatDateCell(customer.createdAt)
   return (
     <tr className="hover:bg-muted/40 motion-safe:transition-colors">
       <td className="px-3 py-2.5 font-medium text-foreground">{customer.name}</td>
@@ -92,9 +122,21 @@ function Row({ customer }: { customer: AllCustomerRow }) {
       <td className="px-3 py-2.5">
         <CustomerPipelineBadge pipeline={customer.pipeline} />
       </td>
-      <td className="px-3 py-2.5 text-right text-xs tabular-nums text-muted-foreground">
-        {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-          .format(new Date(customer.createdAt))}
+      <td className="px-3 py-2.5 text-right" onClick={e => e.stopPropagation()}>
+        <DateTimePicker
+          value={new Date(customer.createdAt)}
+          onChange={(date) => {
+            if (date) {
+              onUpdateCreatedAt(date)
+            }
+          }}
+          className="ml-auto"
+        >
+          <div className="flex flex-col items-end">
+            <span className="text-sm font-medium leading-tight">{relative}</span>
+            <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
+          </div>
+        </DateTimePicker>
       </td>
     </tr>
   )

--- a/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
@@ -2,12 +2,16 @@
 
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
 
+import { DateTimePicker } from '@/shared/components/date-time-picker'
 import { Input } from '@/shared/components/ui/input'
 import { Skeleton } from '@/shared/components/ui/skeleton'
+import { useInvalidation } from '@/shared/dal/client/use-invalidation'
 import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
+import { formatDateCell } from '@/shared/lib/formatters'
 import { useTRPC } from '@/trpc/helpers'
 
 type CustomerRow = AppRouterOutputs['leadSourcesRouter']['getCustomers'][number]
@@ -25,6 +29,7 @@ interface LeadSourceCustomersSectionProps {
  */
 export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomersSectionProps) {
   const trpc = useTRPC()
+  const { invalidateCustomer, invalidateLeadSource } = useInvalidation()
   const [search, setSearch] = useState('')
 
   const { data, isLoading } = useQuery(
@@ -32,6 +37,17 @@ export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomers
       id: leadSourceId,
       search: search.trim() || undefined,
       limit: 100,
+    }),
+  )
+
+  const updateCreatedAt = useMutation(
+    trpc.customersRouter.updateCreatedAt.mutationOptions({
+      onSuccess: () => {
+        toast.success('Created date updated')
+        invalidateCustomer()
+        invalidateLeadSource()
+      },
+      onError: err => toast.error(err.message),
     }),
   )
 
@@ -80,7 +96,15 @@ export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomers
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-border/40">
-                    {data?.map(c => <CustomerTableRow key={c.id} customer={c} />)}
+                    {data?.map(c => (
+                      <CustomerTableRow
+                        key={c.id}
+                        customer={c}
+                        onUpdateCreatedAt={(date) => {
+                          updateCreatedAt.mutate({ customerId: c.id, createdAt: date.toISOString() })
+                        }}
+                      />
+                    ))}
                   </tbody>
                 </table>
               </div>
@@ -89,7 +113,13 @@ export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomers
   )
 }
 
-function CustomerTableRow({ customer }: { customer: CustomerRow }) {
+interface CustomerTableRowProps {
+  customer: CustomerRow
+  onUpdateCreatedAt: (date: Date) => void
+}
+
+function CustomerTableRow({ customer, onUpdateCreatedAt }: CustomerTableRowProps) {
+  const { relative, dayAtTime } = formatDateCell(customer.createdAt)
   return (
     <tr className="hover:bg-muted/40 motion-safe:transition-colors">
       <td className="px-3 py-2.5 font-medium text-foreground">{customer.name}</td>
@@ -97,9 +127,21 @@ function CustomerTableRow({ customer }: { customer: CustomerRow }) {
       <td className="px-3 py-2.5">
         <CustomerPipelineBadge pipeline={customer.pipeline} />
       </td>
-      <td className="px-3 py-2.5 text-right text-xs tabular-nums text-muted-foreground">
-        {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-          .format(new Date(customer.createdAt))}
+      <td className="px-3 py-2.5 text-right" onClick={e => e.stopPropagation()}>
+        <DateTimePicker
+          value={new Date(customer.createdAt)}
+          onChange={(date) => {
+            if (date) {
+              onUpdateCreatedAt(date)
+            }
+          }}
+          className="ml-auto"
+        >
+          <div className="flex flex-col items-end">
+            <span className="text-sm font-medium leading-tight">{relative}</span>
+            <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
+          </div>
+        </DateTimePicker>
       </td>
     </tr>
   )

--- a/src/trpc/routers/customers.router.ts
+++ b/src/trpc/routers/customers.router.ts
@@ -103,6 +103,35 @@ export const customersRouter = createTRPCRouter({
       return updated
     }),
 
+  // Overwrite a customer's `createdAt` — super-admin only. Legacy Notion
+  // imports land with today's timestamp regardless of when the lead
+  // actually came in, so lead-source stats by range are misleading until
+  // the super-admin corrects them. Lead-source stats depend on this
+  // column, so the caller should invalidate both customer + lead-source
+  // queries on success.
+  updateCreatedAt: agentProcedure
+    .input(z.object({
+      customerId: z.string().uuid(),
+      createdAt: z.string().datetime(),
+    }))
+    .mutation(async ({ input, ctx }) => {
+      if (ctx.session.user.role !== 'super-admin') {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Only super-admins can edit the created date.' })
+      }
+
+      const [updated] = await db
+        .update(customers)
+        .set({ createdAt: input.createdAt })
+        .where(eq(customers.id, input.customerId))
+        .returning({ id: customers.id, createdAt: customers.createdAt })
+
+      if (!updated) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Customer not found' })
+      }
+
+      return updated
+    }),
+
   // Update top-level contact fields — super-admin only
   updateCustomerContact: agentProcedure
     .input(z.object({

--- a/src/trpc/routers/lead-sources.router.ts
+++ b/src/trpc/routers/lead-sources.router.ts
@@ -89,13 +89,14 @@ export const leadSourcesRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       requireSuperAdmin(ctx.session.user.role)
       const includeInactive = input?.includeInactive ?? true
-      const from = input?.from
-      const to = input?.to
 
-      // Build the range predicate as raw SQL fragments that plug into the
-      // correlated subquery below. NULL bounds simply drop their clause.
-      const fromClause = from ? sql`AND ${customers.createdAt} >= ${from}` : sql``
-      const toClause = to ? sql`AND ${customers.createdAt} <= ${to}` : sql``
+      // Interpolating an empty Drizzle `sql` fragment into a correlated
+      // subquery can silently zero out the count (witnessed on "All time"
+      // → every leadsInRange came back 0). Always interpolate a real ISO
+      // string — fall back to epoch/far-future sentinels when the
+      // corresponding boundary is absent so the predicate stays a no-op.
+      const effectiveFrom = input?.from ?? '1970-01-01T00:00:00.000Z'
+      const effectiveTo = input?.to ?? '2999-12-31T23:59:59.999Z'
 
       const rows = await db
         .select({
@@ -113,8 +114,8 @@ export const leadSourcesRouter = createTRPCRouter({
           leadsInRange: sql<number>`(
             SELECT COUNT(*)::int FROM ${customers}
             WHERE ${customers.leadSourceId} = ${leadSourcesTable.id}
-              ${fromClause}
-              ${toClause}
+              AND ${customers.createdAt} >= ${effectiveFrom}
+              AND ${customers.createdAt} <= ${effectiveTo}
           )`,
         })
         .from(leadSourcesTable)


### PR DESCRIPTION
## Summary

One bug fix + one small feature, both tied to the left-col customer count attribution.

## Bug: \`leadsInRange\` returned 0 on "All time"

**Symptom:** Pick the \`All time\` chip → every lead source card in the left column shows \`0\`, even though inside the source's Overview tab the same stat reports the correct total.

**Root cause:** In the \`list\` router (PR #128), the range predicate was built via conditional empty Drizzle \`sql\`\`\` fragments:

\`\`\`ts
const fromClause = from ? sql\`AND ... >= \${from}\` : sql\`\`
const toClause = to ? sql\`AND ... <= \${to}\` : sql\`\`
\`\`\`

Interpolating an empty \`sql\` fragment into a correlated subquery can silently break the count. The per-source \`getStats\` takes a different path (uses composed \`and(...)\` predicates) so it was unaffected.

**Fix:** drop the conditional pattern. Always interpolate real ISO boundaries; when a boundary is absent, use an epoch / far-future sentinel so the predicate stays a mathematical no-op:

\`\`\`ts
const effectiveFrom = input?.from ?? '1970-01-01T00:00:00.000Z'
const effectiveTo = input?.to ?? '2999-12-31T23:59:59.999Z'
\`\`\`

## Feature: editable createdAt in both customer tables

Super-admin clicks the date cell → shared \`DateTimePicker\` opens (same pattern as the proposal-flow table). New \`customersRouter.updateCreatedAt\` mutation, guarded to super-admin. On success both customer + lead-source queries invalidate.

Motivation: legacy Notion imports land with today's timestamp regardless of when the lead actually came in, so time-range stats are skewed until the super-admin corrects them.

## Self-Review

- \`pnpm tsc\` clean
- \`pnpm lint\` clean
- Reused existing \`DateTimePicker\` component (no new primitives)
- Mutation invalidates both customer + lead-source routers since \`createdAt\` drives both

## Test plan
- [ ] Select \`All time\` chip → left-col stats match \`totalLeads\` column semantics (non-zero)
- [ ] Select \`7d\`/year/etc. → left-col stats match the range
- [ ] Click a customer's Created cell → picker opens; pick a new datetime → toast confirms; stats refresh with new attribution
- [ ] Non-super-admin hitting the endpoint directly → FORBIDDEN

Follow-ups queued: mobile responsiveness, redo source Overview top section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)