### PR TITLE
refactor(lead-sources): replace sentinel dates with FILTER aggregate

### DIFF
--- a/src/trpc/routers/lead-sources.router.ts
+++ b/src/trpc/routers/lead-sources.router.ts
@@ -54,6 +54,15 @@ function customersMatchingSource(leadSourceId: string) {
   return eq(customers.leadSourceId, leadSourceId)
 }
 
+// Build the optional [gte(from), lte(to)] predicate pair against customers.createdAt.
+// Returned array is spread-friendly: `and(baseMatch, ...customerCreatedAtInRange(…))`.
+function customerCreatedAtInRange(from?: string, to?: string) {
+  return [
+    from ? gte(customers.createdAt, from) : undefined,
+    to ? lte(customers.createdAt, to) : undefined,
+  ].filter(Boolean)
+}
+
 // ── Schemas ─────────────────────────────────────────────────────────────────
 
 const timeRangeInput = z.object({
@@ -90,13 +99,9 @@ export const leadSourcesRouter = createTRPCRouter({
       requireSuperAdmin(ctx.session.user.role)
       const includeInactive = input?.includeInactive ?? true
 
-      // Interpolating an empty Drizzle `sql` fragment into a correlated
-      // subquery can silently zero out the count (witnessed on "All time"
-      // → every leadsInRange came back 0). Always interpolate a real ISO
-      // string — fall back to epoch/far-future sentinels when the
-      // corresponding boundary is absent so the predicate stays a no-op.
-      const effectiveFrom = input?.from ?? '1970-01-01T00:00:00.000Z'
-      const effectiveTo = input?.to ?? '2999-12-31T23:59:59.999Z'
+      const rangePredicates = customerCreatedAtInRange(input?.from, input?.to)
+      const rangePredicate = rangePredicates.length > 0 ? and(...rangePredicates) : undefined
+      const totalLeads = sql<number>`COUNT(${customers.id})::int`
 
       const rows = await db
         .select({
@@ -107,19 +112,15 @@ export const leadSourcesRouter = createTRPCRouter({
           isActive: leadSourcesTable.isActive,
           createdAt: leadSourcesTable.createdAt,
           updatedAt: leadSourcesTable.updatedAt,
-          totalLeads: sql<number>`(
-            SELECT COUNT(*)::int FROM ${customers}
-            WHERE ${customers.leadSourceId} = ${leadSourcesTable.id}
-          )`,
-          leadsInRange: sql<number>`(
-            SELECT COUNT(*)::int FROM ${customers}
-            WHERE ${customers.leadSourceId} = ${leadSourcesTable.id}
-              AND ${customers.createdAt} >= ${effectiveFrom}
-              AND ${customers.createdAt} <= ${effectiveTo}
-          )`,
+          totalLeads,
+          leadsInRange: rangePredicate
+            ? sql<number>`COUNT(${customers.id}) FILTER (WHERE ${rangePredicate})::int`
+            : totalLeads,
         })
         .from(leadSourcesTable)
+        .leftJoin(customers, eq(customers.leadSourceId, leadSourcesTable.id))
         .where(includeInactive ? undefined : eq(leadSourcesTable.isActive, true))
+        .groupBy(leadSourcesTable.id)
         .orderBy(desc(leadSourcesTable.isActive), asc(leadSourcesTable.name))
 
       return rows
@@ -155,15 +156,8 @@ export const leadSourcesRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Lead source not found.' })
       }
 
-      const rangeFrom = input.from ? new Date(input.from) : null
-      const rangeTo = input.to ? new Date(input.to) : null
-
       const baseMatch = customersMatchingSource(src.id)
-
-      const rangeClauses = [
-        rangeFrom ? gte(customers.createdAt, rangeFrom.toISOString()) : undefined,
-        rangeTo ? lte(customers.createdAt, rangeTo.toISOString()) : undefined,
-      ].filter(Boolean)
+      const rangeClauses = customerCreatedAtInRange(input.from, input.to)
 
       const [totalRow] = await db
         .select({ count: sql<number>`COUNT(*)::int` })
@@ -202,12 +196,7 @@ export const leadSourcesRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       requireSuperAdmin(ctx.session.user.role)
 
-      const rangeFrom = input.from ? new Date(input.from) : null
-      const rangeTo = input.to ? new Date(input.to) : null
-      const rangeClauses = [
-        rangeFrom ? gte(customers.createdAt, rangeFrom.toISOString()) : undefined,
-        rangeTo ? lte(customers.createdAt, rangeTo.toISOString()) : undefined,
-      ].filter(Boolean)
+      const rangeClauses = customerCreatedAtInRange(input.from, input.to)
 
       const [totalRow] = await db
         .select({ count: sql<number>`COUNT(*)::int` })


### PR DESCRIPTION
## Summary
- Rewrote `leadSourcesRouter.list` to drop the `1970-…` / `2999-…` sentinel-date band-aid and the correlated subqueries it lived in. Now a single `leftJoin` + `groupBy` with `COUNT(customers.id) FILTER (WHERE …)::int` for `leadsInRange`. When no range is supplied, `leadsInRange` aliases `totalLeads` directly — no FILTER clause emitted, no magic dates.
- Extracted `customerCreatedAtInRange(from?, to?)` helper (co-located with `customersMatchingSource`) and applied it to `getStats` and `getAggregateStats` — retires three copies of the `[gte, lte].filter(Boolean)` pattern and the redundant `new Date(...).toISOString()` round-trips those procedures ran on already-validated ISO strings.

## Changes
- `src/trpc/routers/lead-sources.router.ts` — `list` rewrite + `customerCreatedAtInRange` helper + apply helper to `getStats` / `getAggregateStats`.

## Self-Review
- Return shape of `list` unchanged — no caller impact.
- `pnpm tsc` clean, `pnpm lint` clean (only pre-existing warnings in unrelated files).
- `groupBy(leadSourcesTable.id)` relies on Postgres's PK functional-dependency rule (SQL:1999) — this codebase is Postgres-only (Neon), so safe.
- `.filter(Boolean)` typing is consistent with the existing idiom in this file.

## Test Plan
- [x] Dev: "All time" range — every row's `leadsInRange` equals `totalLeads`.
- [x] Dev: `7d` range — `leadsInRange` matches `getStats` for a spot-checked source.
- [x] Sources with zero customers still return `totalLeads: 0` / `leadsInRange: 0`.