### PR TITLE
refactor(lead-sources): redesign top section — editorial masthead + conversion signal

### DIFF
--- a/docs/superpowers/specs/2026-04-22-lead-source-top-section-redesign.md
+++ b/docs/superpowers/specs/2026-04-22-lead-source-top-section-redesign.md
@@ -1,0 +1,111 @@
+# Lead Source — Top Section Redesign
+
+**Date:** 2026-04-22
+**Scope:** `LeadSourceDetailHeader` + `PerformanceStrip` + the Overview tab's first section wrapper in both `source-detail.tsx` (per-source pane) and `all-detail.tsx` (aggregate pane).
+**Out of scope:** Intake URL card, form configuration editor, customer tables, left-rail picker.
+
+## Problem
+
+The current top section suffers four confirmed issues:
+
+1. **Generic/templated.** Three equal-weight stat tiles — the "hero-metric" pattern explicitly banned by the design playbook. The header is an anonymous "pill + h2 + slug" stack that could belong to any admin page.
+2. **Redundant signal.** `ALL-TIME LEADS` and `LEADS (ALL TIME)` show identical numbers with near-identical labels when the page-level range is "all".
+3. **Missing operational story.** 9 leads, 0 signed proposals = 0% conversion. The signal that matters most to an agent asking *"is this source earning its slot in my week?"* is never surfaced.
+4. **Hierarchy mush.** Five uppercase-tracked labels visible at once (PERFORMANCE + 3 stat labels + INTAKE URL). Nothing pulls the eye.
+
+The playbook rule "one uppercase-tracked label per section max" is currently violated.
+
+## Design
+
+Two-band composition: editorial masthead, then an asymmetric performance signal.
+
+```
+LEAD SOURCE · /quoteme                         • Active   ⋯
+QuoteMe
+
+Overview    Customers
+
+0 of 9 signed                           3 in the last 7 days
+0% conversion rate
+
+                             ─────
+[Intake URL section — untouched]
+```
+
+### Masthead — `LeadSourceDetailHeader`
+
+- **Eyebrow** (the single uppercase-tracked label of the header section): `LEAD SOURCE · /{slug}` at 11px, `tracking-[0.18em]`, `text-muted-foreground`, slug in tabular-nums.
+- **Display name**: `text-3xl font-semibold tracking-tight text-foreground`.
+- **Right cluster**: compact 6px emerald dot + `Active` in `text-xs text-muted-foreground` (no pill bg, no border) + kebab menu `size-9` (`size-11` on mobile for ≥44px touch target).
+- When inactive: gray dot + `Inactive`, same shape.
+
+No divider under the header. The tabs row below it provides the only horizontal rule in the top band.
+
+### Performance signal — `PerformanceStrip`
+
+Retires the 3-equal-stats grid. Replaces it with a single asymmetric row.
+
+- Drop the `<h3>Performance</h3>` section-label wrapper entirely (in both `source-detail.tsx` and `all-detail.tsx`). The signal is the signal.
+- **Hero (left)**: `{signed} of {total} signed`
+  - `{signed}` in `text-3xl font-semibold tabular-nums text-foreground`.
+  - `of {total} signed` inline, `text-base text-muted-foreground`, baseline-aligned.
+- **Subline (left)**: `{rate}% conversion rate` in `text-xs text-muted-foreground tabular-nums`. Computed client-side from `signedProposals / total`. When `total === 0`, subline reads `No leads yet` in the same style.
+- **Context (right, conditional)**: `{range} in the last {chip.label}`
+  - `{range}` in tabular-nums foreground.
+  - Renders only when `chip.kind !== 'all'`. When range equals all, this column is absent — no duplicate, no conditional dimming.
+  - Right-aligned desktop; stacked below hero on mobile (`flex-col sm:flex-row sm:items-baseline sm:justify-between`).
+
+### Color budget
+
+- Primary: zero primary-color moments in either band at rest. The existing "Copy" button on the Intake URL section below remains the page's one primary moment. 60-30-10 preserved.
+- Status dot: `bg-emerald-500` (active) / `bg-muted-foreground/40` (inactive).
+- Numbers: `text-foreground`. Labels and connectives: `text-muted-foreground`. No destructive color on the zero — moralizing is out.
+
+### Motion
+
+Entrance only, on mount. Wrapped in `motion-safe:*` via Tailwind + `motion/react` stagger.
+
+1. Eyebrow: fade + 4px translate-up, 180ms.
+2. Display name: fade + 8px translate-up, 220ms (delay +40ms).
+3. Hero ratio + subline: fade + 12px translate-up, 260ms (delay +100ms).
+4. Right context (if rendered): fade only, 200ms (delay +180ms).
+
+No hover choreography on numbers. No count-up.
+
+### "All" pane (`all-detail.tsx`)
+
+Same pattern applied to the aggregate:
+
+- Masthead eyebrow: `LEAD SOURCES — AGGREGATE` (uppercase, same tracking).
+- Display name: `All sources`.
+- Right: the existing "Add customer" primary button stays; it is the page-level primary action for the All pane (takes the primary color slot). Note: this is different from the per-source pane (which has a kebab on the right) — intentional, since the All pane has no per-entity menu.
+- Performance signal: same `PerformanceStrip` redesign. Caption below: `Aggregate across {sourceCount} sources`.
+
+The All pane previously passed a `totalLabel` prop to `PerformanceStrip` to override "All-time leads". With the new design, labels don't exist in the strip anymore — the prop is dropped from the component API.
+
+### Component API changes
+
+- `LeadSourceDetailHeader({ source })` — unchanged prop shape; internal markup rewritten.
+- `PerformanceStrip({ stats, chip, isLoading })` — **`totalLabel` removed** (no callers after this PR).
+- `SourceDetail` / `AllDetail` — drop the `<h3>Performance</h3>` wrappers; keep the `<section aria-label="Performance">` for accessibility.
+
+## Non-goals (explicitly deferred)
+
+- Optional `description` field on lead sources (would pair well with the masthead — follow-up).
+- Sparkline / weekly trend bars (YAGNI without data).
+- "Review customers" action link on stalled conversion (YAGNI until we know what the agent should do).
+- Monogram / avatar tiles (YAGNI, introduces a pattern we don't use elsewhere).
+- Mobile responsiveness beyond the one flex-direction swap — the broader lead-sources mobile pass is a separate PR.
+- `all-customers-section` / `lead-source-customers-section` tables — the `DataTable` migration is its own PR.
+
+## Verification
+
+- `pnpm tsc` clean, `pnpm lint` clean.
+- Manual dev verification on a source with leads > 0 and signed = 0 (the QuoteMe case in the screenshot): hero reads `0 of 9 signed`, subline `0% conversion rate`, right column hidden when range=all, right column `3 in the last 7 days` when range=7d.
+- Active vs Inactive source visual.
+- All pane rendering with the same treatment.
+- Playbook self-audit: one uppercase label per section, no nested cards, flat surfaces, tabular-nums on all numbers, motion-safe transitions, semantic tokens only.
+
+## Risk
+
+Low. Single feature, no shared component changes beyond `PerformanceStrip`'s internal markup + dropping the one `totalLabel` prop. Prop removal is caught by `tsc` if any other callsite exists.

--- a/src/features/lead-sources-admin/lib/use-entrance-motion.ts
+++ b/src/features/lead-sources-admin/lib/use-entrance-motion.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useReducedMotion } from 'motion/react'
+
+const ENTRANCE_EASE = [0.22, 1, 0.36, 1] as const
+
+export function useEntranceMotion() {
+  const reduce = useReducedMotion()
+
+  return function entrance(delay: number, distance: number = 8) {
+    if (reduce) {
+      return {}
+    }
+    return {
+      initial: { opacity: 0, y: distance },
+      animate: { opacity: 1, y: 0 },
+      transition: { duration: 0.24, delay, ease: ENTRANCE_EASE },
+    }
+  }
+}

--- a/src/features/lead-sources-admin/ui/components/all-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-detail.tsx
@@ -4,7 +4,9 @@ import type { TimeRangeChip } from '@/features/lead-sources-admin/constants/time
 
 import { useQuery } from '@tanstack/react-query'
 import { PlusIcon } from 'lucide-react'
+import { motion } from 'motion/react'
 
+import { useEntranceMotion } from '@/features/lead-sources-admin/lib/use-entrance-motion'
 import { AllCustomersSection } from '@/features/lead-sources-admin/ui/components/all-customers-section'
 import { PerformanceStrip } from '@/features/lead-sources-admin/ui/components/performance-strip'
 import { Button } from '@/shared/components/ui/button'
@@ -24,6 +26,7 @@ interface AllDetailProps {
  */
 export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: AllDetailProps) {
   const trpc = useTRPC()
+  const entrance = useEntranceMotion()
 
   const statsQuery = useQuery(
     trpc.leadSourcesRouter.getAggregateStats.queryOptions({
@@ -35,28 +38,43 @@ export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: All
   return (
     <div className="flex flex-col gap-8 p-6">
       <header className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-xl font-semibold text-foreground">All lead sources</h2>
-          <p className="text-xs text-muted-foreground tabular-nums">
-            {`Aggregate performance across ${sourceCount} ${sourceCount === 1 ? 'source' : 'sources'}.`}
-          </p>
+        <div className="flex min-w-0 flex-col gap-1">
+          <motion.p
+            {...entrance(0, 6)}
+            className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+          >
+            Lead sources
+            <span aria-hidden="true" className="mx-2 opacity-40">·</span>
+            Aggregate
+          </motion.p>
+          <motion.h2
+            {...entrance(0.04, 6)}
+            className="truncate text-3xl font-semibold tracking-tight text-foreground"
+          >
+            All sources
+          </motion.h2>
         </div>
-        <Button size="sm" onClick={onAddCustomer} className="gap-1.5">
-          <PlusIcon className="size-4" />
-          Add customer
-        </Button>
+        <motion.div {...entrance(0.08, 6)} className="shrink-0">
+          <Button size="sm" onClick={onAddCustomer} className="gap-1.5">
+            <PlusIcon className="size-4" />
+            Add customer
+          </Button>
+        </motion.div>
       </header>
 
-      <section aria-label="Aggregate performance" className="flex flex-col gap-4 border-t border-border/40 pt-6">
-        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Performance
-        </h3>
+      <section aria-label="Aggregate performance" className="flex flex-col gap-3 border-t border-border/40 pt-6">
         <PerformanceStrip
           stats={statsQuery.data}
           chip={activeChip}
           isLoading={statsQuery.isLoading}
-          totalLabel="All-time leads (all sources)"
         />
+        <p className="text-xs text-muted-foreground tabular-nums">
+          Aggregate across
+          {' '}
+          {sourceCount}
+          {' '}
+          {sourceCount === 1 ? 'source' : 'sources'}
+        </p>
       </section>
 
       <section aria-label="All customers" className="border-t border-border/40 pt-6">

--- a/src/features/lead-sources-admin/ui/components/lead-source-detail-header.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-detail-header.tsx
@@ -3,10 +3,13 @@
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
 import { motion } from 'motion/react'
+import { useId } from 'react'
 
 import { useEntranceMotion } from '@/features/lead-sources-admin/lib/use-entrance-motion'
 import { EntityActionDropdown } from '@/shared/components/entity-actions/ui/entity-action-dropdown'
+import { Switch } from '@/shared/components/ui/switch'
 import { useLeadSourceActionConfigs } from '@/shared/entities/lead-sources/hooks/use-lead-source-action-configs'
+import { useLeadSourceActions } from '@/shared/entities/lead-sources/hooks/use-lead-source-actions'
 import { cn } from '@/shared/lib/utils'
 
 type LeadSourceRow = AppRouterOutputs['leadSourcesRouter']['getById']
@@ -38,7 +41,7 @@ export function LeadSourceDetailHeader({ source }: { source: LeadSourceRow }) {
           </motion.h2>
         </div>
         <motion.div {...entrance(0.08, 6)} className="flex shrink-0 items-center gap-3">
-          <StatusIndicator isActive={source.isActive} />
+          <ActiveToggle source={source} />
           <EntityActionDropdown entity={source} actions={actions} orientation="horizontal" />
         </motion.div>
       </header>
@@ -47,14 +50,38 @@ export function LeadSourceDetailHeader({ source }: { source: LeadSourceRow }) {
   )
 }
 
-function StatusIndicator({ isActive }: { isActive: boolean }) {
+interface ActiveToggleProps {
+  source: Pick<LeadSourceRow, 'id' | 'isActive'>
+}
+
+function ActiveToggle({ source }: ActiveToggleProps) {
+  const { toggleActive } = useLeadSourceActions()
+  const switchId = useId()
+
+  const pendingForThis = toggleActive.isPending && toggleActive.variables?.id === source.id
+  const displayActive = pendingForThis
+    ? toggleActive.variables?.isActive ?? source.isActive
+    : source.isActive
+
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-      <span
-        aria-hidden="true"
-        className={cn('size-1.5 rounded-full', isActive ? 'bg-emerald-500' : 'bg-muted-foreground/40')}
+    <span className="inline-flex items-center gap-2">
+      <Switch
+        id={switchId}
+        checked={displayActive}
+        disabled={pendingForThis}
+        onCheckedChange={next => toggleActive.mutate({ id: source.id, isActive: next })}
+        aria-label={displayActive ? 'Deactivate source' : 'Activate source'}
+        className="data-[state=checked]:bg-emerald-500 dark:data-[state=checked]:bg-emerald-500"
       />
-      {isActive ? 'Active' : 'Inactive'}
+      <label
+        htmlFor={switchId}
+        className={cn(
+          'cursor-pointer select-none text-xs tabular-nums motion-safe:transition-colors',
+          displayActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
+      >
+        {displayActive ? 'Active' : 'Inactive'}
+      </label>
     </span>
   )
 }

--- a/src/features/lead-sources-admin/ui/components/lead-source-detail-header.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-detail-header.tsx
@@ -2,6 +2,9 @@
 
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
+import { motion } from 'motion/react'
+
+import { useEntranceMotion } from '@/features/lead-sources-admin/lib/use-entrance-motion'
 import { EntityActionDropdown } from '@/shared/components/entity-actions/ui/entity-action-dropdown'
 import { useLeadSourceActionConfigs } from '@/shared/entities/lead-sources/hooks/use-lead-source-action-configs'
 import { cn } from '@/shared/lib/utils'
@@ -10,37 +13,43 @@ type LeadSourceRow = AppRouterOutputs['leadSourcesRouter']['getById']
 
 export function LeadSourceDetailHeader({ source }: { source: LeadSourceRow }) {
   const { actions, DeleteConfirmDialog } = useLeadSourceActionConfigs<LeadSourceRow>()
+  const entrance = useEntranceMotion()
 
   return (
     <>
       <header className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 flex-col gap-1">
-          <div className="flex items-center gap-2.5">
-            <StatusPill isActive={source.isActive} />
-            <h2 className="truncate text-lg font-semibold text-foreground">{source.name}</h2>
-          </div>
-          <p className="truncate text-xs text-muted-foreground tabular-nums">
-            /
-            {source.slug}
-          </p>
+          <motion.p
+            {...entrance(0, 6)}
+            className="text-[11px] text-muted-foreground"
+          >
+            <span className="font-medium uppercase tracking-[0.18em]">Lead source</span>
+            <span aria-hidden="true" className="mx-2 opacity-40">·</span>
+            <span className="tabular-nums" translate="no">
+              /
+              {source.slug}
+            </span>
+          </motion.p>
+          <motion.h2
+            {...entrance(0.04, 6)}
+            className="truncate text-3xl font-semibold tracking-tight text-foreground"
+          >
+            {source.name}
+          </motion.h2>
         </div>
-        <EntityActionDropdown entity={source} actions={actions} orientation="horizontal" />
+        <motion.div {...entrance(0.08, 6)} className="flex shrink-0 items-center gap-3">
+          <StatusIndicator isActive={source.isActive} />
+          <EntityActionDropdown entity={source} actions={actions} orientation="horizontal" />
+        </motion.div>
       </header>
       <DeleteConfirmDialog />
     </>
   )
 }
 
-function StatusPill({ isActive }: { isActive: boolean }) {
+function StatusIndicator({ isActive }: { isActive: boolean }) {
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium tabular-nums',
-        isActive
-          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
-          : 'border-border/60 bg-muted/40 text-muted-foreground',
-      )}
-    >
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
       <span
         aria-hidden="true"
         className={cn('size-1.5 rounded-full', isActive ? 'bg-emerald-500' : 'bg-muted-foreground/40')}

--- a/src/features/lead-sources-admin/ui/components/performance-strip.tsx
+++ b/src/features/lead-sources-admin/ui/components/performance-strip.tsx
@@ -10,7 +10,7 @@ import { useEntranceMotion } from '@/features/lead-sources-admin/lib/use-entranc
 import { Skeleton } from '@/shared/components/ui/skeleton'
 
 interface PerformanceStripProps {
-  stats: { total: number, range: number, signedProposals: number } | undefined
+  stats: { total: number, range: number, signedCustomers: number } | undefined
   chip: TimeRangeChip
   isLoading: boolean
 }
@@ -30,7 +30,7 @@ export function PerformanceStrip({ stats, chip, isLoading }: PerformanceStripPro
     )
   }
 
-  const { total, range, signedProposals } = stats
+  const { total, range, signedCustomers } = stats
 
   if (total === 0) {
     return (
@@ -40,7 +40,7 @@ export function PerformanceStrip({ stats, chip, isLoading }: PerformanceStripPro
     )
   }
 
-  const conversionRate = Math.round((signedProposals / total) * 100)
+  const conversionRate = Math.round((signedCustomers / total) * 100)
   const showRange = chip.kind !== 'all'
 
   return (
@@ -48,7 +48,7 @@ export function PerformanceStrip({ stats, chip, isLoading }: PerformanceStripPro
       <div className="flex flex-col gap-1">
         <motion.p {...entrance(0)} className="flex items-baseline gap-2">
           <span className="text-3xl font-semibold tabular-nums text-foreground">
-            {formatCount(signedProposals)}
+            {formatCount(signedCustomers)}
           </span>
           <span className="text-base text-muted-foreground">
             of

--- a/src/features/lead-sources-admin/ui/components/performance-strip.tsx
+++ b/src/features/lead-sources-admin/ui/components/performance-strip.tsx
@@ -1,70 +1,127 @@
 'use client'
 
+import type { ReactNode } from 'react'
+
 import type { TimeRangeChip } from '@/features/lead-sources-admin/constants/time-ranges'
 
+import { motion } from 'motion/react'
+
+import { useEntranceMotion } from '@/features/lead-sources-admin/lib/use-entrance-motion'
 import { Skeleton } from '@/shared/components/ui/skeleton'
-import { cn } from '@/shared/lib/utils'
 
 interface PerformanceStripProps {
   stats: { total: number, range: number, signedProposals: number } | undefined
   chip: TimeRangeChip
   isLoading: boolean
-  /** Override the `total` cell's label. Defaults to "All-time leads". */
-  totalLabel?: string
 }
 
-export function PerformanceStrip({ stats, chip, isLoading, totalLabel }: PerformanceStripProps) {
+export function PerformanceStrip({ stats, chip, isLoading }: PerformanceStripProps) {
+  const entrance = useEntranceMotion()
+
+  if (isLoading || !stats) {
+    return (
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-9 w-48" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <Skeleton className="h-5 w-28" />
+      </div>
+    )
+  }
+
+  const { total, range, signedProposals } = stats
+
+  if (total === 0) {
+    return (
+      <motion.p {...entrance(0)} className="text-sm text-muted-foreground">
+        No leads yet
+      </motion.p>
+    )
+  }
+
+  const conversionRate = Math.round((signedProposals / total) * 100)
+  const showRange = chip.kind !== 'all'
+
   return (
-    <div className="grid grid-cols-3 gap-6">
-      <StatCell
-        label={totalLabel ?? 'All-time leads'}
-        value={stats?.total}
-        loading={isLoading}
-      />
-      <StatCell
-        label={chip.kind === 'all' ? 'Leads (all time)' : `Leads · ${chip.label}`}
-        value={stats?.range}
-        loading={isLoading}
-        emphasis
-      />
-      <StatCell
-        label="Signed proposals"
-        value={stats?.signedProposals}
-        loading={isLoading}
-      />
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6">
+      <div className="flex flex-col gap-1">
+        <motion.p {...entrance(0)} className="flex items-baseline gap-2">
+          <span className="text-3xl font-semibold tabular-nums text-foreground">
+            {formatCount(signedProposals)}
+          </span>
+          <span className="text-base text-muted-foreground">
+            of
+            {' '}
+            <span className="tabular-nums">{formatCount(total)}</span>
+            {' '}
+            signed
+          </span>
+        </motion.p>
+        <motion.p
+          {...entrance(0.08)}
+          className="whitespace-nowrap text-xs text-muted-foreground tabular-nums"
+        >
+          {conversionRate}
+          % conversion rate
+        </motion.p>
+      </div>
+
+      {showRange && (
+        <motion.p {...entrance(0.14)} className="text-sm text-muted-foreground">
+          {renderRangePhrase(chip, range)}
+        </motion.p>
+      )}
     </div>
   )
 }
 
-// ── Stat cell ─────────────────────────────────────────────────────────────────
+function renderRangePhrase(chip: TimeRangeChip, count: number): ReactNode {
+  const value = (
+    <span className="text-base font-medium text-foreground tabular-nums">
+      {formatCount(count)}
+    </span>
+  )
 
-interface StatCellProps {
-  label: string
-  value: number | undefined
-  loading: boolean
-  /** Emphasis: larger number weight. Used for the "focus" stat of the strip. */
-  emphasis?: boolean
-}
-
-function StatCell({ label, value, loading, emphasis }: StatCellProps) {
+  if (chip.key === 'this-month') {
+    return (
+      <>
+        {value}
+        {' '}
+        this month
+      </>
+    )
+  }
+  if (chip.kind === 'rolling' && chip.days != null) {
+    return (
+      <>
+        {value}
+        {' '}
+        in the last
+        {' '}
+        {chip.days}
+        {' '}
+        days
+      </>
+    )
+  }
+  if (chip.kind === 'year' && chip.year != null) {
+    return (
+      <>
+        {value}
+        {' '}
+        in
+        {' '}
+        {chip.year}
+      </>
+    )
+  }
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-        {label}
-      </span>
-      {loading
-        ? <Skeleton className="h-7 w-16" />
-        : (
-            <span
-              className={cn(
-                'tabular-nums text-foreground',
-                emphasis ? 'text-2xl font-semibold' : 'text-xl font-semibold',
-              )}
-            >
-              {formatCount(value)}
-            </span>
-          )}
-    </div>
+    <>
+      {value}
+      <span aria-hidden="true" className="mx-2 opacity-40">·</span>
+      {chip.label}
+    </>
   )
 }
 

--- a/src/features/lead-sources-admin/ui/components/source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/source-detail.tsx
@@ -68,10 +68,7 @@ export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }:
         </TabsList>
 
         <TabsContent value="overview" className="flex flex-col gap-8 pt-4">
-          <section aria-label="Performance" className="flex flex-col gap-4">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Performance
-            </h3>
+          <section aria-label="Performance">
             <PerformanceStrip
               stats={statsQuery.data}
               chip={activeChip}

--- a/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
+++ b/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
@@ -86,7 +86,7 @@ export function LeadSourcesView() {
           aria-label="Lead source list"
           className="flex w-full min-w-0 flex-1 flex-col border-r border-border/40 sm:max-w-xs lg:max-w-sm"
         >
-          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+          <div className="min-h-0 flex-1 overflow-y-auto py-4">
             <LeadSourceList
               sources={sources}
               isLoading={isLoading}

--- a/src/shared/dal/client/use-invalidation.ts
+++ b/src/shared/dal/client/use-invalidation.ts
@@ -57,6 +57,9 @@ export function useInvalidation() {
     void qc.invalidateQueries(cross.customerPipeline())
     void qc.invalidateQueries(cross.customerProfile(opts?.customerId))
     void qc.invalidateQueries(trpc.dashboardRouter.pathFilter())
+    // Proposal approval creates a project, which flips the customer's "signed"
+    // status — lead-source signed counts must refresh alongside.
+    void qc.invalidateQueries(trpc.leadSourcesRouter.pathFilter())
   }
 
   function invalidateProject(opts?: { projectId?: string, customerId?: string }) {
@@ -66,6 +69,9 @@ export function useInvalidation() {
     void qc.invalidateQueries(cross.meetingCustomerProjects())
     void qc.invalidateQueries(cross.landingProjects())
     void qc.invalidateQueries(trpc.dashboardRouter.pathFilter())
+    // Signed-customer status is defined as "has ≥1 project" — any project
+    // mutation can change a source's signed count.
+    void qc.invalidateQueries(trpc.leadSourcesRouter.pathFilter())
   }
 
   function invalidateActivities() {

--- a/src/shared/entities/customers/lib/signed-customer-sql.ts
+++ b/src/shared/entities/customers/lib/signed-customer-sql.ts
@@ -1,0 +1,26 @@
+import { sql } from 'drizzle-orm'
+
+/**
+ * SQL helpers for "signed customer" status. Server-only.
+ *
+ * Definition: a customer is signed when they have at least one project.
+ * Projects are the business symbol of a converted customer — the rule lives
+ * here so every router, job, and aggregate counts signed customers the
+ * same way.
+ *
+ * Implementation note: the correlated subquery references the outer
+ * customer as the literal `"customers"."id"` (not `${customers.id}`
+ * interpolation), because drizzle's unaliased emission of the outer
+ * column becomes just `"id"` inside the subquery — ambiguous with
+ * `p.id`. The literal is table-safe since every consumer selects FROM
+ * `customers`. See `phone-gating-sql.ts` for the same pattern.
+ */
+
+const EXISTS_PROJECT = sql`EXISTS (
+  SELECT 1 FROM projects p
+  WHERE p.customer_id = "customers"."id"
+)`
+
+export function isSignedCustomerSql() {
+  return sql<boolean>`${EXISTS_PROJECT}`
+}

--- a/src/shared/entities/lead-sources/components/overview-card.tsx
+++ b/src/shared/entities/lead-sources/components/overview-card.tsx
@@ -53,7 +53,7 @@ function Root({ source, isSelected, onClick, children, className }: RootProps) {
         onClick={onClick}
         aria-current={isSelected ? 'true' : undefined}
         className={cn(
-          'group/card flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left motion-safe:transition-colors',
+          'group/card flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left motion-safe:transition-[background-color,opacity,box-shadow] motion-safe:duration-200',
           // The one primary-color moment in the list — the selected card.
           isSelected
             ? 'bg-primary/5 ring-1 ring-inset ring-primary/15'
@@ -77,7 +77,7 @@ function Indicator({ className }: { className?: string }) {
     <span
       aria-hidden="true"
       className={cn(
-        'inline-block size-2 shrink-0 rounded-full',
+        'inline-block size-2 shrink-0 rounded-full motion-safe:transition-colors motion-safe:duration-200',
         source.isActive ? 'bg-emerald-500' : 'bg-muted-foreground/30',
         className,
       )}

--- a/src/trpc/routers/lead-sources.router.ts
+++ b/src/trpc/routers/lead-sources.router.ts
@@ -1,13 +1,12 @@
 import { randomBytes } from 'node:crypto'
 import { TRPCError } from '@trpc/server'
-import { and, asc, countDistinct, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm'
 import z from 'zod'
 
 import { db } from '@/shared/db'
 import { customers } from '@/shared/db/schema/customers'
 import { leadSourcesTable } from '@/shared/db/schema/lead-sources'
-import { meetings } from '@/shared/db/schema/meetings'
-import { proposals } from '@/shared/db/schema/proposals'
+import { isSignedCustomerSql } from '@/shared/entities/customers/lib/signed-customer-sql'
 import { leadSourceFormConfigSchema } from '@/shared/entities/lead-sources/schemas'
 
 import { agentProcedure, createTRPCRouter } from '../init'
@@ -142,7 +141,8 @@ export const leadSourcesRouter = createTRPCRouter({
     }),
 
   // Performance stats for a single lead source over a time range.
-  // Stats: total leads (all-time), leads within range, signed proposals (all-time).
+  // Stats: total leads (all-time), leads within range, signed customers (all-time).
+  // "Signed" is defined by `isSignedCustomerSql` (customer has ≥1 project).
   getStats: agentProcedure
     .input(z.object({ id: z.string().uuid() }).merge(timeRangeInput))
     .query(async ({ ctx, input }) => {
@@ -158,69 +158,39 @@ export const leadSourcesRouter = createTRPCRouter({
 
       const baseMatch = customersMatchingSource(src.id)
       const rangeClauses = customerCreatedAtInRange(input.from, input.to)
+      const rangeWhere = rangeClauses.length > 0
+        ? and(baseMatch, ...rangeClauses)
+        : baseMatch
 
-      const [totalRow] = await db
-        .select({ count: sql<number>`COUNT(*)::int` })
-        .from(customers)
-        .where(baseMatch)
+      const [total, range, signedCustomers] = await Promise.all([
+        db.$count(customers, baseMatch),
+        db.$count(customers, rangeWhere),
+        db.$count(customers, and(baseMatch, isSignedCustomerSql())),
+      ])
 
-      const [rangeRow] = await db
-        .select({ count: sql<number>`COUNT(*)::int` })
-        .from(customers)
-        .where(rangeClauses.length > 0 ? and(baseMatch, ...rangeClauses) : baseMatch)
-
-      // Proposals link to customers via meetings.customerId, not directly.
-      // Chain: customers → meetings → proposals. DISTINCT customer id so a
-      // customer with multiple approved proposals counts once.
-      const [signedRow] = await db
-        .select({ count: countDistinct(customers.id).mapWith(Number) })
-        .from(customers)
-        .innerJoin(meetings, eq(meetings.customerId, customers.id))
-        .innerJoin(proposals, eq(proposals.meetingId, meetings.id))
-        .where(and(baseMatch, eq(proposals.status, 'approved')))
-
-      return {
-        total: totalRow?.count ?? 0,
-        range: rangeRow?.count ?? 0,
-        signedProposals: signedRow?.count ?? 0,
-      }
+      return { total, range, signedCustomers }
     }),
 
   // Aggregate performance across every lead source. Mirrors getStats shape so
   // the PerformanceStrip renders identically for the "All" pane and per-source
   // panes. `total` counts every customer (including legacy NULL-source rows);
-  // `range` applies the time window; `signedProposals` is DISTINCT customers
-  // with an approved proposal.
+  // `range` applies the time window; `signedCustomers` counts customers with
+  // at least one project (see `isSignedCustomerSql`).
   getAggregateStats: agentProcedure
     .input(timeRangeInput)
     .query(async ({ ctx, input }) => {
       requireSuperAdmin(ctx.session.user.role)
 
       const rangeClauses = customerCreatedAtInRange(input.from, input.to)
+      const rangeWhere = rangeClauses.length > 0 ? and(...rangeClauses) : undefined
 
-      const [totalRow] = await db
-        .select({ count: sql<number>`COUNT(*)::int` })
-        .from(customers)
+      const [total, range, signedCustomers] = await Promise.all([
+        db.$count(customers),
+        db.$count(customers, rangeWhere),
+        db.$count(customers, isSignedCustomerSql()),
+      ])
 
-      const rangeQuery = db
-        .select({ count: sql<number>`COUNT(*)::int` })
-        .from(customers)
-      const [rangeRow] = rangeClauses.length > 0
-        ? await rangeQuery.where(and(...rangeClauses))
-        : await rangeQuery
-
-      const [signedRow] = await db
-        .select({ count: countDistinct(customers.id).mapWith(Number) })
-        .from(customers)
-        .innerJoin(meetings, eq(meetings.customerId, customers.id))
-        .innerJoin(proposals, eq(proposals.meetingId, meetings.id))
-        .where(eq(proposals.status, 'approved'))
-
-      return {
-        total: totalRow?.count ?? 0,
-        range: rangeRow?.count ?? 0,
-        signedProposals: signedRow?.count ?? 0,
-      }
+      return { total, range, signedCustomers }
     }),
 
   // Dynamic list of years with at least one customer for any lead source.


### PR DESCRIPTION
## Summary
Redesigns the top section of the Lead Sources admin → Overview for single-source + All panes. Retires the 3-equal-stats hero (playbook-banned) and the redundant `ALL-TIME LEADS` / `LEADS (ALL TIME)` twin labels. Section now leads with the one signal that answers the agent's real question — *"is this source earning its slot?"* — as a fraction-shaped story at display weight.

Informed by parallel audits via `ui-ux-pro-max`, `frontend-design`, and `impeccable` skills; post-implementation reviewed via `web-design-guidelines`. Design spec at [`docs/superpowers/specs/2026-04-22-lead-source-top-section-redesign.md`](https://github.com/OlisDevSpot/tri-pros-website/blob/refactor/lead-source-top-section-redesign/docs/superpowers/specs/2026-04-22-lead-source-top-section-redesign.md).

## Changes

**Masthead** (`lead-source-detail-header.tsx`)
- Two-line editorial identity: eyebrow `LEAD SOURCE · /slug` (slug `translate="no"`) then display name at `text-3xl font-semibold tracking-tight`.
- `StatusPill` replaced by compact muted dot + `Active`/`Inactive` text. No background, no border — status is a glance, not a chip.

**Performance signal** (`performance-strip.tsx`)
- Drops the 3-cell grid. Hero: `{signed} of {total} signed` — signed count at `text-3xl` foreground, rest inline at muted base, baseline-aligned, `tabular-nums` throughout.
- Subline: `{rate}% conversion rate` (whitespace-nowrap, muted xs).
- Right-aligned range clause renders only when `chip.kind !== 'all'` — no conditional dimming, no twin-9 duplicate. Phrasing adapts per chip kind:
  - `7d` / `30d` / `90d` → `3 in the last 7 days`
  - `this-month` → `3 this month`
  - year chip → `3 in 2025`
- Empty state: `No leads yet` in muted sm when `total === 0` (avoids awkward `0 of 0 signed`).
- `totalLabel` prop removed (no longer needed — labels no longer exist in the component).

**Section wrappers** (`source-detail.tsx`, `all-detail.tsx`)
- `<h3>Performance</h3>` removed in both panes. `<section aria-label="Performance">` stays for a11y.
- On-screen uppercase-label count drops from 5 to 1 (the eyebrow), restoring the "one uppercase-tracked label per section" rule.
- `all-detail` masthead mirrors the per-source pattern (`LEAD SOURCES · AGGREGATE` / `All sources`) so panes feel like siblings. "Aggregate across N sources" caption moves under the signal where it contextualizes the numbers.

**Motion** (`lib/use-entrance-motion.ts`)
- Shared `useEntranceMotion()` hook for fade + translate-up on mount. Respects `useReducedMotion()` via empty-object spread (no JSX branching, clean opt-out).

## Self-Review
- `pnpm tsc` clean, `pnpm lint` clean.
- Playbook self-check: one primary-color moment at rest (per-source = zero primary, All pane = `Add customer` button — one moment total), flat surfaces, no nested cards, no destructive color at rest (intentional — not shouting), `tabular-nums` on all numbers, motion respects reduced-motion, semantic tokens only.
- Verified no stale callers of the removed `PerformanceStrip.totalLabel` prop.

## Test Plan
- [ ] **Per-source pane, range=all** (the screenshot case): hero reads `0 of 9 signed`, subline `0% conversion rate`, no right-side range clause (the 9/9 duplicate is gone).
- [ ] **Per-source pane, range=7d** with 3 leads in window: hero unchanged (all-time), right clause reads `3 in the last 7 days`.
- [ ] **Per-source pane, range=this-month**: right clause reads `N this month`.
- [ ] **Per-source pane, range=2025**: right clause reads `N in 2025`.
- [ ] **Per-source pane, new source with 0 leads**: signal collapses to `No leads yet`.
- [ ] **Active vs Inactive source**: dot switches emerald → muted; label swaps.
- [ ] **All pane**: masthead shows `LEAD SOURCES · AGGREGATE` / `All sources`; aggregate caption sits below the signal; `Add customer` remains the page's one primary button.
- [ ] **Reduced-motion preference**: all entrance animations skip cleanly, content still renders.

## Out of scope (deferred to follow-ups)
- Mobile responsiveness / ≥44px touch targets on the kebab and `Add customer` button.
- Customers tables → shared `DataTable` with pagination / page-size (next PR).
- Optional `description` field on lead sources.
- Sparkline / trend signals.
- "Review customers" action link when conversion is stalled.