### PR TITLE
feat(lead-sources): customer tables on shared DataTable with server pagination

### DIFF
--- a/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
@@ -2,36 +2,65 @@
 
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
-import { useMutation, useQuery } from '@tanstack/react-query'
-import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs'
+import { useCallback, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 
-import { DateTimePicker } from '@/shared/components/date-time-picker'
+import { buildCustomerColumns } from '@/features/lead-sources-admin/ui/components/customer-table-columns'
+import { DataTable } from '@/shared/components/data-table/ui/data-table'
 import { Input } from '@/shared/components/ui/input'
-import { Skeleton } from '@/shared/components/ui/skeleton'
 import { useInvalidation } from '@/shared/dal/client/use-invalidation'
-import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
-import { formatDateCell } from '@/shared/lib/formatters'
+import { CustomerProfileModal } from '@/shared/entities/customers/components/profile/customer-profile-modal'
+import { useCustomerActionConfigs } from '@/shared/entities/customers/hooks/use-customer-action-configs'
+import { useDebounce } from '@/shared/hooks/use-debounce'
+import { useModalStore } from '@/shared/hooks/use-modal-store'
 import { useTRPC } from '@/trpc/helpers'
 
-type AllCustomerRow = AppRouterOutputs['leadSourcesRouter']['getAllCustomers'][number]
+type AllCustomerRow = AppRouterOutputs['leadSourcesRouter']['getAllCustomers']['rows'][number]
 
-/**
- * Lightweight cross-source customers table. Same shape as
- * LeadSourceCustomersSection but with an added "Source" column. Will be
- * replaced by the shared DataTable primitive in a follow-up pass.
- */
+const PAGE_SIZE = 15
+
 export function AllCustomersSection() {
   const trpc = useTRPC()
+  const qc = useQueryClient()
   const { invalidateCustomer, invalidateLeadSource } = useInvalidation()
-  const [search, setSearch] = useState('')
+  const { setModal, open: openModal } = useModalStore()
 
-  const { data, isLoading } = useQuery(
-    trpc.leadSourcesRouter.getAllCustomers.queryOptions({
-      search: search.trim() || undefined,
-      limit: 100,
+  const [page, setPage] = useQueryState('ap', parseAsInteger.withDefault(1))
+  const [rawSearch, setRawSearch] = useQueryState('aq', parseAsString.withDefault(''))
+  const search = useDebounce(rawSearch.trim(), 250)
+
+  const offset = (Math.max(page, 1) - 1) * PAGE_SIZE
+  const queryInput = useMemo(
+    () => ({
+      search: search || undefined,
+      limit: PAGE_SIZE,
+      offset,
     }),
+    [search, offset],
   )
+
+  const { data, isLoading, isFetching } = useQuery(
+    trpc.leadSourcesRouter.getAllCustomers.queryOptions(queryInput),
+  )
+
+  // Prefetch the next page so Next-click is instant.
+  useEffect(() => {
+    if (!data) {
+      return
+    }
+    const hasNext = offset + PAGE_SIZE < data.total
+    if (!hasNext) {
+      return
+    }
+    void qc.prefetchQuery(
+      trpc.leadSourcesRouter.getAllCustomers.queryOptions({
+        ...queryInput,
+        offset: offset + PAGE_SIZE,
+      }),
+    )
+  }, [data, offset, queryInput, qc, trpc.leadSourcesRouter.getAllCustomers])
 
   const updateCreatedAt = useMutation(
     trpc.customersRouter.updateCreatedAt.mutationOptions({
@@ -44,117 +73,80 @@ export function AllCustomersSection() {
     }),
   )
 
-  const total = data?.length ?? 0
+  const handleViewProfile = useCallback((customerId: string) => {
+    setModal({
+      accessor: 'CustomerProfile',
+      Component: CustomerProfileModal,
+      props: { customerId },
+    })
+    openModal()
+  }, [setModal, openModal])
 
-  const header = useMemo(() => (
-    <div className="flex items-end justify-between gap-4">
-      <div className="flex flex-col gap-1">
-        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          All customers
-        </h3>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {isLoading ? 'Loading…' : `${total} shown`}
-        </span>
-      </div>
-      <Input
-        type="search"
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-        placeholder="Filter by name or email…"
-        autoComplete="off"
-        spellCheck={false}
-        className="max-w-xs"
-      />
-    </div>
-  ), [isLoading, total, search])
+  const { actions, DeleteConfirmDialog } = useCustomerActionConfigs<AllCustomerRow>({
+    onView: entity => handleViewProfile(entity.id),
+  })
 
-  return (
-    <section aria-label="All customers" className="flex flex-col gap-3">
-      {header}
-      {isLoading
-        ? <Skeleton className="h-56 w-full" />
-        : total === 0
-          ? <EmptyState search={search} />
-          : (
-              <div className="overflow-hidden rounded-lg border border-border/60">
-                <table className="w-full text-sm">
-                  <thead className="border-b border-border/60 bg-muted/40">
-                    <tr className="text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      <th className="px-3 py-2">Name</th>
-                      <th className="px-3 py-2">Email</th>
-                      <th className="px-3 py-2">Source</th>
-                      <th className="px-3 py-2">Pipeline</th>
-                      <th className="px-3 py-2 text-right">Created</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/40">
-                    {data?.map(c => (
-                      <Row
-                        key={c.id}
-                        customer={c}
-                        onUpdateCreatedAt={(date) => {
-                          updateCreatedAt.mutate({ customerId: c.id, createdAt: date.toISOString() })
-                        }}
-                      />
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-    </section>
+  const columns = useMemo(
+    () => buildCustomerColumns<AllCustomerRow>({ includeSource: true }),
+    [],
   )
-}
 
-interface RowProps {
-  customer: AllCustomerRow
-  onUpdateCreatedAt: (date: Date) => void
-}
+  const meta = useMemo(
+    () => ({
+      customerActions: () => actions,
+      onUpdateCreatedAt: (customerId: string, date: Date) =>
+        updateCreatedAt.mutate({ customerId, createdAt: date.toISOString() }),
+    }),
+    [actions, updateCreatedAt],
+  )
 
-function Row({ customer, onUpdateCreatedAt }: RowProps) {
-  const { relative, dayAtTime } = formatDateCell(customer.createdAt)
+  const total = data?.total ?? 0
+  const rows = data?.rows ?? []
+
   return (
-    <tr className="hover:bg-muted/40 motion-safe:transition-colors">
-      <td className="px-3 py-2.5 font-medium text-foreground">{customer.name}</td>
-      <td className="px-3 py-2.5 text-muted-foreground">{customer.email ?? '—'}</td>
-      <td className="px-3 py-2.5 text-xs text-muted-foreground">
-        {customer.leadSourceName ?? 'Unknown'}
-      </td>
-      <td className="px-3 py-2.5">
-        <CustomerPipelineBadge pipeline={customer.pipeline} />
-      </td>
-      <td className="px-3 py-2.5 text-right" onClick={e => e.stopPropagation()}>
-        <DateTimePicker
-          value={new Date(customer.createdAt)}
-          onChange={(date) => {
-            if (date) {
-              onUpdateCreatedAt(date)
+    <section aria-label="All customers" className="flex min-h-96 flex-col gap-3">
+      <DeleteConfirmDialog />
+
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            All customers
+          </h3>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {isLoading ? 'Loading…' : `${total.toLocaleString()} total`}
+          </span>
+        </div>
+        <Input
+          type="search"
+          value={rawSearch}
+          onChange={(e) => {
+            void setRawSearch(e.target.value || null, { history: 'replace' })
+            if (page !== 1) {
+              void setPage(1, { history: 'replace' })
             }
           }}
-          className="ml-auto"
-        >
-          <div className="flex flex-col items-end">
-            <span className="text-sm font-medium leading-tight">{relative}</span>
-            <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
-          </div>
-        </DateTimePicker>
-      </td>
-    </tr>
-  )
-}
+          placeholder="Filter by name or email…"
+          autoComplete="off"
+          spellCheck={false}
+          className="max-w-xs"
+        />
+      </div>
 
-function EmptyState({ search }: { search: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-border/60 px-4 py-8 text-center text-sm text-muted-foreground">
-      {search
-        ? (
-            <>
-              No customers match
-              {' '}
-              <span className="font-medium text-foreground">{`“${search}”`}</span>
-              .
-            </>
-          )
-        : 'No customers yet. Once leads come in through any intake URL, they\u2019ll appear here.'}
-    </div>
+      <DataTable
+        tableId="all-customers"
+        columns={columns}
+        data={rows}
+        meta={meta}
+        entityName="customer"
+        onRowClick={row => handleViewProfile(row.id)}
+        serverPagination={{
+          pageIndex: Math.max(page, 1) - 1,
+          pageSize: PAGE_SIZE,
+          rowCount: total,
+          onPageChange: nextIndex => setPage(nextIndex + 1, { history: 'push' }),
+          isFetching,
+        }}
+      />
+    </section>
   )
 }

--- a/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-customers-section.tsx
@@ -104,10 +104,10 @@ export function AllCustomersSection() {
   const rows = data?.rows ?? []
 
   return (
-    <section aria-label="All customers" className="flex min-h-96 flex-col gap-3">
+    <section aria-label="All customers" className="flex min-h-0 flex-1 flex-col gap-3">
       <DeleteConfirmDialog />
 
-      <div className="flex items-end justify-between gap-4">
+      <div className="flex shrink-0 items-end justify-between gap-4">
         <div className="flex flex-col gap-1">
           <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             All customers

--- a/src/features/lead-sources-admin/ui/components/all-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-detail.tsx
@@ -36,8 +36,8 @@ export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: All
   )
 
   return (
-    <div className="flex flex-col gap-8 p-6">
-      <header className="flex items-start justify-between gap-4">
+    <div className="flex h-full min-h-0 flex-col gap-8 p-6">
+      <header className="flex shrink-0 items-start justify-between gap-4">
         <div className="flex min-w-0 flex-col gap-1">
           <motion.p
             {...entrance(0, 6)}
@@ -62,7 +62,7 @@ export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: All
         </motion.div>
       </header>
 
-      <section aria-label="Aggregate performance" className="flex flex-col gap-3 border-t border-border/40 pt-6">
+      <section aria-label="Aggregate performance" className="flex shrink-0 flex-col gap-3 border-t border-border/40 pt-6">
         <PerformanceStrip
           stats={statsQuery.data}
           chip={activeChip}
@@ -77,7 +77,7 @@ export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: All
         </p>
       </section>
 
-      <section aria-label="All customers" className="border-t border-border/40 pt-6">
+      <section aria-label="All customers" className="flex min-h-0 flex-1 flex-col border-t border-border/40 pt-6">
         <AllCustomersSection />
       </section>
     </div>

--- a/src/features/lead-sources-admin/ui/components/customer-table-columns.tsx
+++ b/src/features/lead-sources-admin/ui/components/customer-table-columns.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import type { ColumnDef } from '@tanstack/react-table'
+
+import type { EntityActionConfig } from '@/shared/components/entity-actions/types'
+
+import { DateTimePicker } from '@/shared/components/date-time-picker'
+import { EntityActionMenu } from '@/shared/components/entity-actions/ui/entity-action-menu'
+import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
+import { formatDateCell } from '@/shared/lib/formatters'
+
+// ── Row shapes ──────────────────────────────────────────────────────────────
+
+export interface CustomerTableRowBase {
+  id: string
+  name: string
+  email: string | null
+  createdAt: string
+  pipeline: 'active' | 'rehash' | 'dead' | null
+}
+
+export interface CustomerTableRowWithSource extends CustomerTableRowBase {
+  leadSourceName: string | null
+  leadSourceSlug: string | null
+}
+
+// ── Meta ────────────────────────────────────────────────────────────────────
+
+export interface CustomerTableMeta<T extends CustomerTableRowBase> {
+  customerActions: (row: T) => EntityActionConfig<T>[]
+  onUpdateCreatedAt: (customerId: string, date: Date) => void
+  /** When true, the createdAt cell's DateTimePicker is read-only. */
+  readOnlyCreatedAt?: boolean
+}
+
+// ── Columns ─────────────────────────────────────────────────────────────────
+
+interface BuildColumnsOptions {
+  includeSource?: boolean
+}
+
+export function buildCustomerColumns<T extends CustomerTableRowWithSource>(
+  options: BuildColumnsOptions & { includeSource: true },
+): ColumnDef<T>[]
+export function buildCustomerColumns<T extends CustomerTableRowBase>(
+  options?: BuildColumnsOptions & { includeSource?: false },
+): ColumnDef<T>[]
+export function buildCustomerColumns<T extends CustomerTableRowBase>(
+  options: BuildColumnsOptions = {},
+): ColumnDef<T>[] {
+  const columns: ColumnDef<T>[] = [
+    {
+      accessorKey: 'name',
+      header: 'Customer',
+      size: 260,
+      cell: ({ row }) => (
+        <div className="min-w-0 space-y-0.5 p-2">
+          <p className="truncate text-sm font-medium leading-tight text-foreground">
+            {row.original.name}
+          </p>
+          {row.original.email && (
+            <p className="truncate text-xs text-muted-foreground">{row.original.email}</p>
+          )}
+        </div>
+      ),
+    },
+  ]
+
+  if (options.includeSource) {
+    columns.push({
+      id: 'source',
+      header: 'Source',
+      size: 160,
+      accessorFn: (row) => {
+        const r = row as unknown as CustomerTableRowWithSource
+        return r.leadSourceName ?? 'Unknown'
+      },
+      cell: ({ row }) => {
+        const r = row.original as unknown as CustomerTableRowWithSource
+        return (
+          <div className="flex min-w-0 flex-col p-2 leading-tight">
+            <span className="truncate text-sm text-foreground">
+              {r.leadSourceName ?? 'Unknown'}
+            </span>
+            {r.leadSourceSlug && (
+              <span className="truncate text-xs text-muted-foreground tabular-nums" translate="no">
+                /
+                {r.leadSourceSlug}
+              </span>
+            )}
+          </div>
+        )
+      },
+    })
+  }
+
+  columns.push({
+    accessorKey: 'pipeline',
+    header: 'Pipeline',
+    size: 120,
+    cell: ({ row }) => (
+      <div className="p-2">
+        <CustomerPipelineBadge pipeline={row.original.pipeline} />
+      </div>
+    ),
+  })
+
+  columns.push({
+    accessorKey: 'createdAt',
+    header: 'Created',
+    size: 180,
+    cell: ({ row, table }) => {
+      const { relative, dayAtTime } = formatDateCell(row.original.createdAt)
+      const meta = table.options.meta as CustomerTableMeta<T> | undefined
+
+      // Stop propagation so the DateTimePicker popover doesn't trigger
+      // the row-click modal.
+      return (
+        <div
+          className="p-2"
+          onClick={e => e.stopPropagation()}
+        >
+          {meta?.readOnlyCreatedAt || !meta?.onUpdateCreatedAt
+            ? (
+                <div className="flex flex-col leading-tight">
+                  <span className="text-sm font-medium text-foreground">{relative}</span>
+                  <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
+                </div>
+              )
+            : (
+                <DateTimePicker
+                  value={new Date(row.original.createdAt)}
+                  onChange={(date) => {
+                    if (date) {
+                      meta.onUpdateCreatedAt(row.original.id, date)
+                    }
+                  }}
+                >
+                  <div className="flex flex-col leading-tight">
+                    <span className="text-sm font-medium text-foreground">{relative}</span>
+                    <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
+                  </div>
+                </DateTimePicker>
+              )}
+        </div>
+      )
+    },
+  })
+
+  columns.push({
+    id: 'actions',
+    header: '',
+    size: 56,
+    enableResizing: false,
+    cell: ({ row, table }) => {
+      const meta = table.options.meta as CustomerTableMeta<T> | undefined
+      if (!meta) {
+        return null
+      }
+      return (
+        <div
+          className="flex items-center justify-end p-2"
+          onClick={e => e.stopPropagation()}
+        >
+          <EntityActionMenu
+            entity={row.original}
+            actions={meta.customerActions(row.original)}
+            mode="compact"
+            className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          />
+        </div>
+      )
+    },
+  })
+
+  return columns
+}

--- a/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
@@ -108,11 +108,11 @@ export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomers
   return (
     <section
       aria-label="Customers from this lead source"
-      className="flex min-h-96 flex-col gap-3"
+      className="flex min-h-0 flex-1 flex-col gap-3"
     >
       <DeleteConfirmDialog />
 
-      <div className="flex items-end justify-between gap-4">
+      <div className="flex shrink-0 items-end justify-between gap-4">
         <div className="flex flex-col gap-1">
           <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Customers from this source

--- a/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-customers-section.tsx
@@ -2,43 +2,70 @@
 
 import type { AppRouterOutputs } from '@/trpc/routers/app'
 
-import { useMutation, useQuery } from '@tanstack/react-query'
-import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs'
+import { useCallback, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 
-import { DateTimePicker } from '@/shared/components/date-time-picker'
+import { buildCustomerColumns } from '@/features/lead-sources-admin/ui/components/customer-table-columns'
+import { DataTable } from '@/shared/components/data-table/ui/data-table'
 import { Input } from '@/shared/components/ui/input'
-import { Skeleton } from '@/shared/components/ui/skeleton'
 import { useInvalidation } from '@/shared/dal/client/use-invalidation'
-import { CustomerPipelineBadge } from '@/shared/entities/customers/components/customer-pipeline-badge'
-import { formatDateCell } from '@/shared/lib/formatters'
+import { CustomerProfileModal } from '@/shared/entities/customers/components/profile/customer-profile-modal'
+import { useCustomerActionConfigs } from '@/shared/entities/customers/hooks/use-customer-action-configs'
+import { useDebounce } from '@/shared/hooks/use-debounce'
+import { useModalStore } from '@/shared/hooks/use-modal-store'
 import { useTRPC } from '@/trpc/helpers'
 
-type CustomerRow = AppRouterOutputs['leadSourcesRouter']['getCustomers'][number]
+type CustomerRow = AppRouterOutputs['leadSourcesRouter']['getCustomers']['rows'][number]
+
+const PAGE_SIZE = 15
 
 interface LeadSourceCustomersSectionProps {
   leadSourceId: string
 }
 
-/**
- * Customers from a lead source. Intentionally a thin, local table (not the
- * heavyweight customers-pipelines DataTable) — we want this section to feel
- * lightweight and scan-readable inside the detail pane. When the Records
- * migration (#110) lands, the shared CustomersTable primitive will replace
- * this inline renderer.
- */
 export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomersSectionProps) {
   const trpc = useTRPC()
+  const qc = useQueryClient()
   const { invalidateCustomer, invalidateLeadSource } = useInvalidation()
-  const [search, setSearch] = useState('')
+  const { setModal, open: openModal } = useModalStore()
 
-  const { data, isLoading } = useQuery(
-    trpc.leadSourcesRouter.getCustomers.queryOptions({
+  const [page, setPage] = useQueryState('sp', parseAsInteger.withDefault(1))
+  const [rawSearch, setRawSearch] = useQueryState('sq', parseAsString.withDefault(''))
+  const search = useDebounce(rawSearch.trim(), 250)
+
+  const offset = (Math.max(page, 1) - 1) * PAGE_SIZE
+  const queryInput = useMemo(
+    () => ({
       id: leadSourceId,
-      search: search.trim() || undefined,
-      limit: 100,
+      search: search || undefined,
+      limit: PAGE_SIZE,
+      offset,
     }),
+    [leadSourceId, search, offset],
   )
+
+  const { data, isLoading, isFetching } = useQuery(
+    trpc.leadSourcesRouter.getCustomers.queryOptions(queryInput),
+  )
+
+  // Prefetch the next page so Next-click is instant.
+  useEffect(() => {
+    if (!data) {
+      return
+    }
+    const hasNext = offset + PAGE_SIZE < data.total
+    if (!hasNext) {
+      return
+    }
+    void qc.prefetchQuery(
+      trpc.leadSourcesRouter.getCustomers.queryOptions({
+        ...queryInput,
+        offset: offset + PAGE_SIZE,
+      }),
+    )
+  }, [data, offset, queryInput, qc, trpc.leadSourcesRouter.getCustomers])
 
   const updateCreatedAt = useMutation(
     trpc.customersRouter.updateCreatedAt.mutationOptions({
@@ -51,115 +78,80 @@ export function LeadSourceCustomersSection({ leadSourceId }: LeadSourceCustomers
     }),
   )
 
-  const total = data?.length ?? 0
+  const handleViewProfile = useCallback((customerId: string) => {
+    setModal({
+      accessor: 'CustomerProfile',
+      Component: CustomerProfileModal,
+      props: { customerId },
+    })
+    openModal()
+  }, [setModal, openModal])
 
-  const header = useMemo(() => (
-    <div className="flex items-end justify-between gap-4">
-      <div className="flex flex-col gap-1">
-        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Customers from this source
-        </h3>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {isLoading ? 'Loading…' : `${total} shown`}
-        </span>
-      </div>
-      <Input
-        type="search"
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-        placeholder="Filter by name or email…"
-        autoComplete="off"
-        spellCheck={false}
-        className="max-w-xs"
-      />
-    </div>
-  ), [isLoading, total, search])
+  const { actions, DeleteConfirmDialog } = useCustomerActionConfigs<CustomerRow>({
+    onView: entity => handleViewProfile(entity.id),
+  })
 
-  return (
-    <section aria-label="Customers from this lead source" className="flex flex-col gap-3">
-      {header}
-      {isLoading
-        ? <Skeleton className="h-56 w-full" />
-        : total === 0
-          ? (
-              <EmptyState search={search} />
-            )
-          : (
-              <div className="overflow-hidden rounded-lg border border-border/60">
-                <table className="w-full text-sm">
-                  <thead className="border-b border-border/60 bg-muted/40">
-                    <tr className="text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      <th className="px-3 py-2">Name</th>
-                      <th className="px-3 py-2">Email</th>
-                      <th className="px-3 py-2">Pipeline</th>
-                      <th className="px-3 py-2 text-right">Created</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/40">
-                    {data?.map(c => (
-                      <CustomerTableRow
-                        key={c.id}
-                        customer={c}
-                        onUpdateCreatedAt={(date) => {
-                          updateCreatedAt.mutate({ customerId: c.id, createdAt: date.toISOString() })
-                        }}
-                      />
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-    </section>
+  const columns = useMemo(() => buildCustomerColumns<CustomerRow>(), [])
+
+  const meta = useMemo(
+    () => ({
+      customerActions: () => actions,
+      onUpdateCreatedAt: (customerId: string, date: Date) =>
+        updateCreatedAt.mutate({ customerId, createdAt: date.toISOString() }),
+    }),
+    [actions, updateCreatedAt],
   )
-}
 
-interface CustomerTableRowProps {
-  customer: CustomerRow
-  onUpdateCreatedAt: (date: Date) => void
-}
+  const total = data?.total ?? 0
+  const rows = data?.rows ?? []
 
-function CustomerTableRow({ customer, onUpdateCreatedAt }: CustomerTableRowProps) {
-  const { relative, dayAtTime } = formatDateCell(customer.createdAt)
   return (
-    <tr className="hover:bg-muted/40 motion-safe:transition-colors">
-      <td className="px-3 py-2.5 font-medium text-foreground">{customer.name}</td>
-      <td className="px-3 py-2.5 text-muted-foreground">{customer.email ?? '—'}</td>
-      <td className="px-3 py-2.5">
-        <CustomerPipelineBadge pipeline={customer.pipeline} />
-      </td>
-      <td className="px-3 py-2.5 text-right" onClick={e => e.stopPropagation()}>
-        <DateTimePicker
-          value={new Date(customer.createdAt)}
-          onChange={(date) => {
-            if (date) {
-              onUpdateCreatedAt(date)
+    <section
+      aria-label="Customers from this lead source"
+      className="flex min-h-96 flex-col gap-3"
+    >
+      <DeleteConfirmDialog />
+
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Customers from this source
+          </h3>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {isLoading ? 'Loading…' : `${total.toLocaleString()} total`}
+          </span>
+        </div>
+        <Input
+          type="search"
+          value={rawSearch}
+          onChange={(e) => {
+            void setRawSearch(e.target.value || null, { history: 'replace' })
+            if (page !== 1) {
+              void setPage(1, { history: 'replace' })
             }
           }}
-          className="ml-auto"
-        >
-          <div className="flex flex-col items-end">
-            <span className="text-sm font-medium leading-tight">{relative}</span>
-            <span className="text-xs text-muted-foreground tabular-nums">{dayAtTime}</span>
-          </div>
-        </DateTimePicker>
-      </td>
-    </tr>
-  )
-}
+          placeholder="Filter by name or email…"
+          autoComplete="off"
+          spellCheck={false}
+          className="max-w-xs"
+        />
+      </div>
 
-function EmptyState({ search }: { search: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-border/60 px-4 py-8 text-center text-sm text-muted-foreground">
-      {search
-        ? (
-            <>
-              No customers match
-              {' '}
-              <span className="font-medium text-foreground">{`“${search}”`}</span>
-              .
-            </>
-          )
-        : 'No customers from this lead source yet. New leads will appear here once they come in through the intake URL above.'}
-    </div>
+      <DataTable
+        tableId="lead-source-customers"
+        columns={columns}
+        data={rows}
+        meta={meta}
+        entityName="customer"
+        onRowClick={row => handleViewProfile(row.id)}
+        serverPagination={{
+          pageIndex: Math.max(page, 1) - 1,
+          pageSize: PAGE_SIZE,
+          rowCount: total,
+          onPageChange: nextIndex => setPage(nextIndex + 1, { history: 'push' }),
+          isFetching,
+        }}
+      />
+    </section>
   )
 }

--- a/src/features/lead-sources-admin/ui/components/source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/source-detail.tsx
@@ -58,16 +58,23 @@ export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }:
   const source = sourceQuery.data
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex h-full min-h-0 flex-col gap-6 p-6">
       <LeadSourceDetailHeader source={source} />
 
-      <Tabs value={tab} onValueChange={v => setTab(v as SourceTab, { history: 'replace' })}>
-        <TabsList>
+      <Tabs
+        value={tab}
+        onValueChange={v => setTab(v as SourceTab, { history: 'replace' })}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <TabsList className="shrink-0">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="customers">Customers</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="overview" className="flex flex-col gap-8 pt-4">
+        <TabsContent
+          value="overview"
+          className="flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto pt-4"
+        >
           <section aria-label="Performance">
             <PerformanceStrip
               stats={statsQuery.data}
@@ -85,8 +92,11 @@ export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }:
           </section>
         </TabsContent>
 
-        <TabsContent value="customers" className="flex flex-col gap-4 pt-4">
-          <div className="flex items-center justify-end">
+        <TabsContent
+          value="customers"
+          className="flex min-h-0 flex-1 flex-col gap-4 pt-4"
+        >
+          <div className="flex shrink-0 items-center justify-end">
             <Button
               size="sm"
               onClick={() => onAddCustomer({ slug: source.slug, name: source.name })}

--- a/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
+++ b/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
@@ -107,7 +107,7 @@ export function LeadSourcesView() {
           </div>
         </aside>
 
-        <main className="flex min-w-0 flex-3 flex-col overflow-y-auto">
+        <main className="flex min-h-0 min-w-0 flex-3 flex-col">
           {!isLoading && !hasSources
             ? <EmptyState onCreate={() => setNewSheetOpen(true)} />
             : isAllSelected

--- a/src/shared/components/data-table/types.ts
+++ b/src/shared/components/data-table/types.ts
@@ -49,6 +49,23 @@ export type DataTableFilterConfig
     | DataTableMultiSelectFilter
     | DataTableTimePresetFilter
 
+// -- Server-side pagination control --
+
+/**
+ * Controlled pagination state for server-paged tables. When present, DataTable
+ * switches to `manualPagination` — caller passes the current-page slice as
+ * `data` and reports the global row count via `rowCount`.
+ */
+export interface DataTableServerPagination {
+  pageIndex: number
+  pageSize: number
+  rowCount: number
+  onPageChange: (pageIndex: number) => void
+  onPageSizeChange?: (pageSize: number) => void
+  /** When true, render a muted "Loading…" hint in the pagination bar. */
+  isFetching?: boolean
+}
+
 // -- DataTable props --
 
 export interface DataTableProps<TData, TMeta = unknown> {
@@ -59,6 +76,7 @@ export interface DataTableProps<TData, TMeta = unknown> {
   tableId?: string
   filterConfig?: DataTableFilterConfig[]
   defaultSort?: SortingState
+  /** Client-side page size. Ignored when `serverPagination` is provided. */
   pageSize?: number
   entityName?: string
   rowDataAttribute?: string
@@ -66,4 +84,10 @@ export interface DataTableProps<TData, TMeta = unknown> {
   onRowClick?: (row: TData) => void
   onFilteredCountChange?: (count: number) => void
   onFilteredDataChange?: (data: TData[]) => void
+  /**
+   * Opt into server-side pagination. When set, the caller owns page state and
+   * passes only the current page's rows via `data`. `rowCount` reports the
+   * global total so page-count math stays correct.
+   */
+  serverPagination?: DataTableServerPagination
 }

--- a/src/shared/components/data-table/ui/data-table.tsx
+++ b/src/shared/components/data-table/ui/data-table.tsx
@@ -76,6 +76,7 @@ export function DataTable<TData extends { id: string }, TMeta = unknown>({
   onRowClick,
   onFilteredCountChange,
   onFilteredDataChange,
+  serverPagination,
 }: Props<TData, TMeta>) {
   const isMobile = useIsMobile()
   const [activeRowId, setActiveRowId] = useState<string | null>(null)
@@ -218,18 +219,39 @@ export function DataTable<TData extends { id: string }, TMeta = unknown>({
     columns: patchedColumns,
     filterFns,
     defaultColumn: { minSize: 60, maxSize: 800 },
-    state: { sorting, columnFilters, columnVisibility, columnSizing },
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      columnSizing,
+      ...(serverPagination
+        ? { pagination: { pageIndex: serverPagination.pageIndex, pageSize: serverPagination.pageSize } }
+        : {}),
+    },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnSizingChange: setColumnSizing,
+    onPaginationChange: serverPagination
+      ? (updater) => {
+          const prev = { pageIndex: serverPagination.pageIndex, pageSize: serverPagination.pageSize }
+          const next = typeof updater === 'function' ? updater(prev) : updater
+          if (next.pageIndex !== prev.pageIndex) {
+            serverPagination.onPageChange(next.pageIndex)
+          }
+          if (next.pageSize !== prev.pageSize) {
+            serverPagination.onPageSizeChange?.(next.pageSize)
+          }
+        }
+      : undefined,
     enableColumnResizing: true,
     columnResizeMode: 'onChange',
     autoResetPageIndex: false,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize } },
+    ...(serverPagination
+      ? { manualPagination: true, rowCount: serverPagination.rowCount }
+      : { getPaginationRowModel: getPaginationRowModel(), initialState: { pagination: { pageSize } } }),
     meta: {
       ...meta,
       activeRowId,

--- a/src/trpc/routers/lead-sources.router.ts
+++ b/src/trpc/routers/lead-sources.router.ts
@@ -238,19 +238,24 @@ export const leadSourcesRouter = createTRPCRouter({
           )
         : match
 
-      return db
-        .select({
-          id: customers.id,
-          name: customers.name,
-          email: customers.email,
-          createdAt: customers.createdAt,
-          pipeline: customers.pipeline,
-        })
-        .from(customers)
-        .where(where)
-        .orderBy(desc(customers.createdAt))
-        .limit(input.limit)
-        .offset(input.offset)
+      const [rows, total] = await Promise.all([
+        db
+          .select({
+            id: customers.id,
+            name: customers.name,
+            email: customers.email,
+            createdAt: customers.createdAt,
+            pipeline: customers.pipeline,
+          })
+          .from(customers)
+          .where(where)
+          .orderBy(desc(customers.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.$count(customers, where),
+      ])
+
+      return { rows, total }
     }),
 
   // Customers across every lead source (plus legacy NULL-source rows). Used by
@@ -272,23 +277,28 @@ export const leadSourcesRouter = createTRPCRouter({
           )
         : undefined
 
-      return db
-        .select({
-          id: customers.id,
-          name: customers.name,
-          email: customers.email,
-          createdAt: customers.createdAt,
-          pipeline: customers.pipeline,
-          leadSourceId: customers.leadSourceId,
-          leadSourceName: leadSourcesTable.name,
-          leadSourceSlug: leadSourcesTable.slug,
-        })
-        .from(customers)
-        .leftJoin(leadSourcesTable, eq(leadSourcesTable.id, customers.leadSourceId))
-        .where(where)
-        .orderBy(desc(customers.createdAt))
-        .limit(input.limit)
-        .offset(input.offset)
+      const [rows, total] = await Promise.all([
+        db
+          .select({
+            id: customers.id,
+            name: customers.name,
+            email: customers.email,
+            createdAt: customers.createdAt,
+            pipeline: customers.pipeline,
+            leadSourceId: customers.leadSourceId,
+            leadSourceName: leadSourcesTable.name,
+            leadSourceSlug: leadSourcesTable.slug,
+          })
+          .from(customers)
+          .leftJoin(leadSourcesTable, eq(leadSourcesTable.id, customers.leadSourceId))
+          .where(where)
+          .orderBy(desc(customers.createdAt))
+          .limit(input.limit)
+          .offset(input.offset),
+        db.$count(customers, where),
+      ])
+
+      return { rows, total }
     }),
 
   create: agentProcedure


### PR DESCRIPTION
## Summary
Replaces the two inline `<table>` renderers on the Lead Sources admin page (per-source pane + "All" pane) with the shared `DataTable` primitive, backed by real server-side pagination. We never fetch an entire entity to paginate client-side — page-size is capped, next page is prefetched for instant transitions, and URL state survives refresh.

## Changes

**Server** (`src/trpc/routers/lead-sources.router.ts`)
- `getCustomers` + `getAllCustomers` now return `{ rows, total }`.
- `total` comes from `db.$count(customers, where)` (idiomatic Drizzle). Rows + count fire in parallel via `Promise.all`.

**DataTable primitive** (`src/shared/components/data-table/`)
- New optional `serverPagination` prop. When provided, DataTable flips to TanStack's `manualPagination: true`, exposes caller-owned `{ pageIndex, pageSize, rowCount }`, and routes page-change actions through the caller's `onPageChange`. Omit it — the existing client-side path is untouched, so all other consumers keep working.

**Customer columns** (`customer-table-columns.tsx`)
- `buildCustomerColumns` factory: Customer (name + email), optional Source (name + slug), Pipeline badge, Created (editable `DateTimePicker` keyed off table meta), Actions (`EntityActionMenu` keyed off meta). `includeSource: true` flag carries the All pane's extra column without a second file.
- Popover/menu cells `stopPropagation()` so row-click doesn't fire beneath them.

**Sections** (`lead-source-customers-section.tsx`, `all-customers-section.tsx`)
- **Server-side pagination** via nuqs URL state. Namespaced keys (`sp`/`sq` per-source, `ap`/`aq` All) so pane switching doesn't cross-contaminate state.
- **Debounced search** (250ms via existing `useDebounce`). Any change resets page to 1.
- **Next-page prefetch** via React Query `prefetchQuery` after the current page settles — Next-click is instant.
- **Row-click → CustomerProfileModal** via the shared `useModalStore` (same pattern as `customer-pipeline-view`).
- **Entity actions** via `useCustomerActionConfigs` with `onView` pointed at the profile modal.

## Self-Review
- `pnpm tsc` clean, `pnpm lint` clean (only pre-existing warnings in unrelated files).
- DataTable backward-compat: `serverPagination` is purely additive; existing consumers (`customer-pipeline-table`, etc.) unchanged.
- Server limit kept at max 500 in the schema; pageSize defaults to 15 so offsets stay well within bounds.

## Test Plan
- [ ] **Per-source pane** (e.g. `?id=<uuid>`): default lands on page 1. Next/Previous move through pages; URL updates (`?sp=2`). Search filter narrows; page resets to 1; URL shows `?sq=`.
- [ ] **Prefetch**: load a page with >1 page of rows; Next-click shows no loading flash.
- [ ] **All pane** (`?id=all`): same behaviour, separate URL keys (`ap`/`aq`). Source column shows `leadSourceName` + `/slug` (muted).
- [ ] **Row click**: opens `CustomerProfileModal` for that customer.
- [ ] **Entity actions (kebab)**: visible on hover; View → profile modal; Delete → confirm dialog.
- [ ] **Created cell**: clicking the date opens the DateTimePicker without firing row-click; changing the date updates the customer and refetches.
- [ ] **Mobile / reduced-motion**: pagination + search continue to work; will get full mobile polish in the follow-up responsive PR.

## Out of scope (deferred)
- **Lead Sources mobile responsive** — drill-down list↔detail, horizontal-scroll chips, 44px touch targets. Tracked in memory + on the todo list as the next PR.
- Page-size selector. Other tables in the app don't expose one; can be added when there's a concrete need.