### PR TITLE
refactor(lead-sources): mobile drill-down + horizontal chip scroll + 44px targets

### DIFF
--- a/src/features/lead-sources-admin/ui/components/all-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/all-detail.tsx
@@ -55,7 +55,7 @@ export function AllDetail({ sourceCount, activeChip, range, onAddCustomer }: All
           </motion.h2>
         </div>
         <motion.div {...entrance(0.08, 6)} className="shrink-0">
-          <Button size="sm" onClick={onAddCustomer} className="gap-1.5">
+          <Button size="sm" onClick={onAddCustomer} className="h-11 gap-1.5 sm:h-8">
             <PlusIcon className="size-4" />
             Add customer
           </Button>

--- a/src/features/lead-sources-admin/ui/components/lead-source-list.tsx
+++ b/src/features/lead-sources-admin/ui/components/lead-source-list.tsx
@@ -63,16 +63,19 @@ export function LeadSourceList({ sources, isLoading, selectedId, onSelect, range
       </div>
 
       <nav aria-label="Lead sources" className="flex flex-col gap-1">
-        {/* Pinned "All" pseudo-row — always at top, not filtered, not searchable. */}
-        <AllRow
-          total={allInRange}
-          rangeLabel={rangeLabel}
-          isSelected={isAllSelected}
-          onSelect={() => onSelect(ALL_PSEUDO_ID)}
-          disabled={isLoading}
-        />
+        {/* Pinned "All" pseudo-row — desktop only. On mobile the list itself
+            is the "all" state, so tapping the row would be a no-op. */}
+        <div className="hidden lg:contents">
+          <AllRow
+            total={allInRange}
+            rangeLabel={rangeLabel}
+            isSelected={isAllSelected}
+            onSelect={() => onSelect(ALL_PSEUDO_ID)}
+            disabled={isLoading}
+          />
 
-        <div role="separator" aria-hidden="true" className="mx-1 my-1 h-px bg-border/40" />
+          <div role="separator" aria-hidden="true" className="mx-1 my-1 h-px bg-border/40" />
+        </div>
 
         {isLoading
           ? Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-14 w-full" />)

--- a/src/features/lead-sources-admin/ui/components/mobile-back-button.tsx
+++ b/src/features/lead-sources-admin/ui/components/mobile-back-button.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { ChevronLeftIcon } from 'lucide-react'
+
+import { cn } from '@/shared/lib/utils'
+
+interface MobileBackButtonProps {
+  label: string
+  onClick: () => void
+  className?: string
+}
+
+/**
+ * Back affordance for the mobile drill-down pane. Hidden on lg+ since both
+ * panes are visible side-by-side there.
+ */
+export function MobileBackButton({ label, onClick, className }: MobileBackButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-11 shrink-0 items-center gap-1 self-start pl-0 pr-3 text-sm text-muted-foreground motion-safe:transition-colors hover:text-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 rounded-md',
+        'lg:hidden',
+        className,
+      )}
+    >
+      <ChevronLeftIcon aria-hidden="true" className="size-4" />
+      <span>{label}</span>
+    </button>
+  )
+}

--- a/src/features/lead-sources-admin/ui/components/source-detail.tsx
+++ b/src/features/lead-sources-admin/ui/components/source-detail.tsx
@@ -10,6 +10,7 @@ import { FormConfigEditor } from '@/features/lead-sources-admin/ui/components/fo
 import { IntakeUrlCard } from '@/features/lead-sources-admin/ui/components/intake-url-card'
 import { LeadSourceCustomersSection } from '@/features/lead-sources-admin/ui/components/lead-source-customers-section'
 import { LeadSourceDetailHeader } from '@/features/lead-sources-admin/ui/components/lead-source-detail-header'
+import { MobileBackButton } from '@/features/lead-sources-admin/ui/components/mobile-back-button'
 import { PerformanceStrip } from '@/features/lead-sources-admin/ui/components/performance-strip'
 import { Button } from '@/shared/components/ui/button'
 import { Skeleton } from '@/shared/components/ui/skeleton'
@@ -24,9 +25,11 @@ interface SourceDetailProps {
   activeChip: TimeRangeChip
   range: { from?: string, to?: string }
   onAddCustomer: (source: { slug: string, name: string }) => void
+  /** Pops back to the list on mobile. Button hidden on lg+. */
+  onBack?: () => void
 }
 
-export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }: SourceDetailProps) {
+export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer, onBack }: SourceDetailProps) {
   const trpc = useTRPC()
   const [tab, setTab] = useQueryState(
     'tab',
@@ -59,6 +62,7 @@ export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }:
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-6 p-6">
+      {onBack && <MobileBackButton label="All sources" onClick={onBack} />}
       <LeadSourceDetailHeader source={source} />
 
       <Tabs
@@ -100,7 +104,7 @@ export function SourceDetail({ leadSourceId, activeChip, range, onAddCustomer }:
             <Button
               size="sm"
               onClick={() => onAddCustomer({ slug: source.slug, name: source.name })}
-              className="gap-1.5"
+              className="h-11 gap-1.5 sm:h-8"
             >
               <PlusIcon className="size-4" />
               Add customer

--- a/src/features/lead-sources-admin/ui/components/time-range-chips.tsx
+++ b/src/features/lead-sources-admin/ui/components/time-range-chips.tsx
@@ -12,7 +12,15 @@ interface TimeRangeChipsProps {
 
 export function TimeRangeChips({ chips, value, onChange }: TimeRangeChipsProps) {
   return (
-    <div role="tablist" aria-label="Time range" className="flex flex-wrap gap-1.5">
+    <div
+      role="tablist"
+      aria-label="Time range"
+      className={cn(
+        'flex min-w-0 flex-nowrap gap-1.5 overflow-x-auto',
+        'snap-x snap-mandatory scroll-px-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        'sm:flex-wrap sm:overflow-x-visible sm:snap-none',
+      )}
+    >
       {chips.map((chip) => {
         const isActive = chip.key === value
         return (
@@ -23,7 +31,9 @@ export function TimeRangeChips({ chips, value, onChange }: TimeRangeChipsProps) 
             aria-selected={isActive}
             onClick={() => onChange(chip.key)}
             className={cn(
-              'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium tabular-nums motion-safe:transition-colors',
+              'inline-flex shrink-0 snap-start items-center rounded-full border px-3 text-xs font-medium tabular-nums motion-safe:transition-colors',
+              // Touch target: 44px on mobile, compact on ≥sm.
+              'h-11 sm:h-7 sm:px-2.5 sm:py-1',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
               isActive
                 ? 'border-foreground/20 bg-foreground/5 text-foreground'

--- a/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
+++ b/src/features/lead-sources-admin/ui/views/lead-sources-view.tsx
@@ -17,6 +17,7 @@ import { NewLeadSourceSheet } from '@/features/lead-sources-admin/ui/components/
 import { SourceDetail } from '@/features/lead-sources-admin/ui/components/source-detail'
 import { TimeRangeChips } from '@/features/lead-sources-admin/ui/components/time-range-chips'
 import { Button } from '@/shared/components/ui/button'
+import { cn } from '@/shared/lib/utils'
 import { useTRPC } from '@/trpc/helpers'
 
 interface AddSheetState {
@@ -84,7 +85,12 @@ export function LeadSourcesView() {
       <div className="flex min-h-0 flex-1">
         <aside
           aria-label="Lead source list"
-          className="flex w-full min-w-0 flex-1 flex-col border-r border-border/40 sm:max-w-xs lg:max-w-sm"
+          className={cn(
+            'min-w-0 flex-1 flex-col border-r border-border/40 sm:max-w-xs lg:max-w-sm',
+            // Mobile drill-down: list shows only when no specific source is selected
+            // (i.e. `id=all`). On lg+ the split pane always shows both panes.
+            isAllSelected ? 'flex' : 'hidden lg:flex',
+          )}
         >
           <div className="min-h-0 flex-1 overflow-y-auto py-4">
             <LeadSourceList
@@ -99,7 +105,7 @@ export function LeadSourcesView() {
             <Button
               variant="outline"
               onClick={() => setNewSheetOpen(true)}
-              className="w-full justify-start gap-2 border-dashed text-muted-foreground motion-safe:transition-colors hover:border-solid hover:bg-muted/60 hover:text-foreground"
+              className="h-11 w-full justify-start gap-2 border-dashed text-muted-foreground motion-safe:transition-colors hover:border-solid hover:bg-muted/60 hover:text-foreground sm:h-9"
             >
               <PlusIcon className="size-4" />
               New lead source
@@ -107,7 +113,13 @@ export function LeadSourcesView() {
           </div>
         </aside>
 
-        <main className="flex min-h-0 min-w-0 flex-3 flex-col">
+        <main
+          className={cn(
+            'min-h-0 min-w-0 flex-3 flex-col',
+            // Mobile: main pane only when a specific source is selected. Desktop shows both.
+            isAllSelected ? 'hidden lg:flex' : 'flex',
+          )}
+        >
           {!isLoading && !hasSources
             ? <EmptyState onCreate={() => setNewSheetOpen(true)} />
             : isAllSelected
@@ -125,6 +137,7 @@ export function LeadSourcesView() {
                     activeChip={activeChip}
                     range={range}
                     onAddCustomer={src => setAddSheetState(src)}
+                    onBack={() => setSelectedId(ALL_PSEUDO_ID, { history: 'push' })}
                   />
                 )}
         </main>

--- a/src/shared/entities/lead-sources/components/overview-card.tsx
+++ b/src/shared/entities/lead-sources/components/overview-card.tsx
@@ -53,7 +53,7 @@ function Root({ source, isSelected, onClick, children, className }: RootProps) {
         onClick={onClick}
         aria-current={isSelected ? 'true' : undefined}
         className={cn(
-          'group/card flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left motion-safe:transition-[background-color,opacity,box-shadow] motion-safe:duration-200',
+          'group/card flex min-h-11 w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left motion-safe:transition-[background-color,opacity,box-shadow] motion-safe:duration-200 sm:min-h-0',
           // The one primary-color moment in the list — the selected card.
           isSelected
             ? 'bg-primary/5 ring-1 ring-inset ring-primary/15'


### PR DESCRIPTION
## Summary
Makes the Lead Sources admin page usable on mobile. Split pane collapses into a drill-down, the chip toolbar scrolls horizontally with snap, and interactive elements pick up 44px touch targets.

## Changes

**Drill-down on mobile (<lg)**
- Aside + main render as a two-screen drill-down keyed off the same `?id` URL state that drives the desktop split. `id=all` (or absent default) shows the list; `id=<uuid>` shows the source detail. A `MobileBackButton` in the source detail header pushes `id=all` to return to the list.
- Desktop (lg+): split pane unchanged, both visible.
- The pinned "All" pseudo-row is desktop-only (it was a no-op on mobile — being on the list *is* the "all" state).

**Time-range chips**
- Swaps `flex-wrap` for `flex-nowrap overflow-x-auto snap-x snap-mandatory` on mobile, with `snap-start shrink-0` on each chip so scroll lands crisply. Scrollbar hidden via vendor utilities. Reverts to the original wrap layout at `sm+`.
- Chip height bumps to `h-11` on mobile (`sm:h-7` above) for touch targets.

**Touch targets ≥44px on mobile**
- `Add customer` (both panes) and `New lead source` buttons get responsive `h-11 sm:h-{orig}` sizing.
- `LeadSourceOverviewCard` root gets `min-h-11 sm:min-h-0`.

**New file**
- `mobile-back-button.tsx` — lg-hidden, `ChevronLeft + label` at `h-11`. Used by SourceDetail.

## Self-Review
- `pnpm tsc` clean, `pnpm lint` clean (only the pre-existing `resolveTimeRange` useMemo warning from PR #127 that must stay per the memoisation contract).
- Desktop behaviour is unchanged — all responsive changes are gated behind `sm:` / `lg:` breakpoints.

## Test Plan (mobile viewport)
- [x] Default `/dashboard/lead-sources`: shows the list, time-range chips scroll horizontally with snap, tapping a source navigates to the detail pane.
- [x] Back button on detail returns to the list.
- [x] "All" row not shown in mobile list.
- [x] `Add customer` and `New lead source` buttons are ≥44px tall.
- [x] Source rows are ≥44px tall.
- [x] Desktop (lg+): split pane still visible both panes, no back button.

## Out of scope / follow-up
- Kebab menu (`EntityActionDropdown`) touch target — shared component, belongs in a cross-cutting polish pass.
- `IntakeUrlCard` button sizing on mobile — below the fold on Overview tab.
- Mobile-dedicated aggregate screen (replacing AllDetail on small viewports) — ship if needed.