### PR TITLE
fix(zoho-sign): always attach SOW PDF — base/senior templates trimmed

### DIFF
--- a/scripts/inspect-failed-proposal.ts
+++ b/scripts/inspect-failed-proposal.ts
@@ -98,7 +98,9 @@ async function main() {
       },
     } as unknown as Parameters<typeof buildSigningRequest>[0]
 
-    const req = buildSigningRequest(proposal)
+    // Inspection-only: pass a stand-in sowPages — production counts pages
+    // from the generated PDF, but here we only simulate body construction.
+    const req = buildSigningRequest(proposal, { sowPages: 1 })
     console.log('✅ buildSigningRequest SUCCESS')
     console.log('  templateId:        ', req.templateId)
     const ft = req.body.templates.field_data.field_text_data as Record<string, string>

--- a/scripts/replay-zoho-draft.ts
+++ b/scripts/replay-zoho-draft.ts
@@ -55,7 +55,11 @@ async function main() {
     },
   } as unknown as Parameters<typeof buildSigningRequest>[0]
 
-  const { templateId, body } = buildSigningRequest(proposal)
+  // Replay-only: actual production path counts pages from the generated
+  // PDF. For this replay we pass a stand-in page count — the value flows
+  // into the request `notes` field, doesn't affect template selection or
+  // any signed-doc content.
+  const { templateId, body } = buildSigningRequest(proposal, { sowPages: 1 })
   console.log('templateId:', templateId)
 
   const token = await getZohoAccessToken()

--- a/scripts/verify-build-signing-request.ts
+++ b/scripts/verify-build-signing-request.ts
@@ -2,8 +2,7 @@
 import assert from 'node:assert/strict'
 import { buildSigningRequest } from '@/shared/services/zoho-sign/lib/build-signing-request'
 
-// Short path: tiny SOW content
-const shortProposal = {
+const proposal = {
   customer: {
     customerAge: 40,
     name: 'Test Customer',
@@ -19,7 +18,7 @@ const shortProposal = {
       sow: [{
         contentJSON: JSON.stringify({
           type: 'doc',
-          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Short scope of work.' }] }],
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Scope of work.' }] }],
         }),
         html: '',
         scopes: [],
@@ -34,35 +33,33 @@ const shortProposal = {
   },
 } as unknown as Parameters<typeof buildSigningRequest>[0]
 
-const short = buildSigningRequest(shortProposal)
-assert.equal(short.mode, 'short', 'short SOW routes to short path')
-assert.ok(short.body.templates.field_data.field_text_data['sow-1'].length > 0, 'sow-1 populated')
-assert.equal(short.body.templates.field_data.field_text_data['sow-2'], '', 'sow-2 empty for tiny scope')
-console.log('✅ short path')
+const result = buildSigningRequest(proposal, { sowPages: 3 })
+const fields = result.body.templates.field_data.field_text_data
 
-// Long path: force mode=long, supply sowPages
-const longProposal = {
-  ...shortProposal,
-  projectJSON: {
-    data: {
-      ...shortProposal.projectJSON.data,
-      sow: Array.from({ length: 3 }, () => shortProposal.projectJSON.data.sow[0]),
-    },
-  },
-} as unknown as Parameters<typeof buildSigningRequest>[0]
+// Templates were trimmed: sow-1 / sow-2 must NOT be in field_text_data anymore.
+// Sending unknown labels is silently ignored by Zoho but it's dead weight + a
+// confusing signal in payload-inspection logs.
+assert.equal('sow-1' in fields, false, 'sow-1 must not be sent (template field removed)')
+assert.equal('sow-2' in fields, false, 'sow-2 must not be sent (template field removed)')
 
-const long = buildSigningRequest(longProposal, { mode: 'long', sowPages: 3 })
-assert.equal(long.mode, 'long')
-assert.match(long.body.templates.field_data.field_text_data['sow-1'], /See attached.*3 pages/)
-assert.equal(long.body.templates.field_data.field_text_data['sow-2'], '')
-console.log('✅ long path')
+// Core fields the template actually has.
+assert.equal(fields['ho-name'], 'Test Customer')
+assert.equal(fields['ho-email'], 'test@example.com')
+assert.equal(fields['ho-age'], '40')
+assert.equal(fields['tcp'], '5000')
+assert.equal(fields.deposit, '1000')
 
-// Long mode without sowPages throws
+// Page-count flows into the envelope notes for signer context.
+assert.match(result.body.templates.notes, /3 pages/)
+
+// sowPages is required.
 assert.throws(
-  () => buildSigningRequest(longProposal, { mode: 'long' }),
-  /sowPages required/,
-  'throws when sowPages missing in long mode',
+  () => buildSigningRequest(proposal, undefined as unknown as { sowPages: number }),
+  /Cannot/,
+  'throws when options missing',
 )
-console.log('✅ long mode sowPages guard')
 
-console.log('\n✅ buildSigningRequest branching verified')
+console.log('✅ field_text_data has no sow-1/sow-2')
+console.log('✅ core homeowner + financial fields populated')
+console.log('✅ sowPages page-count surfaced in envelope notes')
+console.log('\n✅ buildSigningRequest verified (post-trim, always-attach-PDF shape)')

--- a/src/shared/services/contract.service.ts
+++ b/src/shared/services/contract.service.ts
@@ -1,13 +1,11 @@
 import type { Buffer } from 'node:buffer'
 import type { ZohoActionStatus, ZohoContractStatus, ZohoRequestStatus } from '@/shared/services/zoho-sign/types'
 import { getProposal, updateProposal } from '@/shared/dal/server/proposals/api'
-import { sowToPlaintext } from '@/shared/lib/tiptap-to-text'
 import { pdfService } from '@/shared/services/pdf.service'
 import { countPdfPages } from '@/shared/services/pdf/count-pdf-pages'
 import { ZOHO_SIGN_BASE_URL } from '@/shared/services/zoho-sign/constants'
 import { buildSigningRequest } from '@/shared/services/zoho-sign/lib/build-signing-request'
 import { getZohoAccessToken } from '@/shared/services/zoho-sign/lib/get-access-token'
-import { isLongSow } from '@/shared/services/zoho-sign/lib/is-long-sow'
 
 interface ZohoCreateDocResponse {
   requests: {
@@ -107,10 +105,20 @@ function createContractService() {
   }
 
   /**
-   * Creates a Zoho Sign draft for a proposal. Branches on SOW length:
-   * - short path: single template call, sow-1/sow-2 populated by the packer
-   * - long path: generate SOW PDF → create template draft with pointer text
-   *              in sow-1 → attach PDF via addFilesToRequest → save request ID
+   * Creates a Zoho Sign draft for a proposal. Always generates a SOW PDF
+   * and attaches it to the envelope.
+   *
+   * The base + senior HI templates were trimmed (sow-1/sow-2 fields
+   * removed) — every signed contract now reads SOW content from the
+   * attached PDF, regardless of length. The previous short/long branch
+   * (inlining short SOWs into sow-1/sow-2) is dead because those fields
+   * no longer exist on the templates; routing through the inline path
+   * would silently lose the SOW content.
+   *
+   * Phase 4 of the composable-templating migration will replace this
+   * with a registry-driven assembler that handles upsells via the AWD
+   * template (where short SOW does inline). Until then, every proposal
+   * — initial or upsell — uses base/senior + attached PDF.
    */
   async function createDraft(proposalId: string, ownerKey: string | null) {
     const proposal = await getProposal(proposalId)
@@ -118,22 +126,9 @@ function createContractService() {
       throw new Error(`Proposal ${proposalId} not found`)
     }
 
-    // Decide path BEFORE building the request — buildSigningRequest in long
-    // mode requires sowPages, which we only know after generating the PDF.
-    const sowText = sowToPlaintext(proposal.projectJSON.data.sow ?? [])
-
-    if (!isLongSow(sowText)) {
-      const { templateId, body } = buildSigningRequest(proposal, { mode: 'short' })
-      const res = await createFromTemplate(templateId, body, false)
-      const { requestId, status } = await parseDraftResponse(res)
-      await updateProposal(ownerKey, proposalId, { signingRequestId: requestId })
-      return { requestId, status }
-    }
-
-    // Long path: generate SOW PDF first, then build the request with accurate page count.
     const pdfBuffer = await pdfService.generateSowPdf({ proposalId })
     const sowPages = await countPdfPages(pdfBuffer)
-    const { templateId, body } = buildSigningRequest(proposal, { mode: 'long', sowPages })
+    const { templateId, body } = buildSigningRequest(proposal, { sowPages })
 
     const createRes = await createFromTemplate(templateId, body, false)
     const { requestId, status } = await parseDraftResponse(createRes)

--- a/src/shared/services/zoho-sign/lib/build-signing-request.ts
+++ b/src/shared/services/zoho-sign/lib/build-signing-request.ts
@@ -1,18 +1,17 @@
 import type { ProposalWithCustomer } from '@/shared/dal/server/proposals/api'
 import { computeFinalTcp } from '@/shared/entities/proposals/lib/compute-final-tcp'
-import { sowToPlaintext } from '@/shared/lib/tiptap-to-text'
 import { ZOHO_SIGN_TEMPLATES } from '../constants'
-import { isLongSow } from './is-long-sow'
-import { packSowText } from './pack-sow-text'
 
 interface BuildOptions {
-  /** Explicit path override. Defaults to auto-detection via isLongSow. */
-  mode?: 'short' | 'long'
-  /** Required when mode === 'long'; used in sow-1 pointer text. */
-  sowPages?: number
+  /**
+   * Page count of the attached SOW PDF. Required — the request body's
+   * notes field references it so signers can confirm at-a-glance the
+   * envelope's SOW pagination matches what they reviewed.
+   */
+  sowPages: number
 }
 
-export function buildSigningRequest(proposal: ProposalWithCustomer, options: BuildOptions = {}) {
+export function buildSigningRequest(proposal: ProposalWithCustomer, { sowPages }: BuildOptions) {
   const { customer, projectJSON, fundingJSON } = proposal
   const { data: project } = projectJSON
   const { data: funding } = fundingJSON
@@ -32,28 +31,6 @@ export function buildSigningRequest(proposal: ProposalWithCustomer, options: Bui
   const isSenior = customer.customerAge >= 65
   const { templateId, actions: actionIds } = isSenior ? ZOHO_SIGN_TEMPLATES.senior : ZOHO_SIGN_TEMPLATES.base
 
-  const sowText = sowToPlaintext(proposal.projectJSON.data.sow ?? [])
-  const mode = options.mode ?? (isLongSow(sowText) ? 'long' : 'short')
-
-  let sow1: string
-  let sow2: string
-  if (mode === 'long') {
-    const pages = options.sowPages
-    if (pages == null) {
-      throw new Error('buildSigningRequest: sowPages required in long mode')
-    }
-    sow1 = `See attached Scope of Work document (${pages} ${pages === 1 ? 'page' : 'pages'}) — full details of the Proposed Scope of Work.`
-    sow2 = ''
-  }
-  else {
-    const packed = packSowText(sowText)
-    if (packed.overflow > 0) {
-      throw new Error(`buildSigningRequest: unexpected overflow (${packed.overflow} chars) on short path — route to long path`)
-    }
-    sow1 = packed.sow1
-    sow2 = packed.sow2
-  }
-
   const validThroughTimeframe = Number(project.validThroughTimeframe.replace(/\D/g, ''))
   const startDate = new Date()
   const completionDate = new Date()
@@ -63,7 +40,6 @@ export function buildSigningRequest(proposal: ProposalWithCustomer, options: Bui
 
   return {
     templateId,
-    mode,
     body: {
       templates: {
         field_data: {
@@ -73,8 +49,6 @@ export function buildSigningRequest(proposal: ProposalWithCustomer, options: Bui
             'ho-age': String(customer.customerAge),
             'start-date': startDate.toLocaleDateString(),
             'completion-date': completionDate.toLocaleDateString(),
-            'sow-1': sow1,
-            'sow-2': sow2,
             'tcp': String(computeFinalTcp(funding)),
             'deposit': String(funding.depositAmount),
             'ho-address': customerAddress,
@@ -103,7 +77,7 @@ export function buildSigningRequest(proposal: ProposalWithCustomer, options: Bui
             verification_type: 'EMAIL',
           },
         ],
-        notes: '',
+        notes: `Scope of Work attached as a separate document (${sowPages} ${sowPages === 1 ? 'page' : 'pages'}).`,
       },
     },
   }


### PR DESCRIPTION
## Summary

The base + senior `tpr-HI` templates were trimmed in Zoho UI today (sow-1 / sow-2 removed). Until that change, the legacy short path inlined SOW content into those fields — now Zoho silently ignores the unknown labels and the SOW content disappears from the signed contract for any proposal under the 3600-char threshold. **Long-SOW proposals were unaffected** (PDF attached separately).

This forces every draft creation through the always-attach-PDF path:
- `contract.service.ts createDraft` drops the `isLongSow` branch. Always generates the SOW PDF, counts pages, attaches via `addFilesToRequest`. Same logic as the existing long path, unconditional.
- `build-signing-request.ts` drops `mode` parameter, `packSowText` / `isLongSow` imports, and `sow-1` / `sow-2` from `field_text_data`. The `notes` field carries the page count for signer context.
- `verify-build-signing-request.ts` rewritten — asserts `sow-1`/`sow-2` are NOT in `field_text_data` and that page count surfaces in notes.
- `replay-zoho-draft.ts` + `inspect-failed-proposal.ts` updated for the new required `sowPages` argument (inspection scripts pass a stand-in value).

## Why this is urgent

Production status: any proposal drafted with a short SOW between the trim landing and this PR shipping has lost its SOW content in the signed contract. No error surfaced — Zoho silently accepts unknown field labels.

## Behavior change

- **Initial-sale short SOW:** previously inlined into `sow-1`/`sow-2`, now attaches a generated PDF. Matches the contractual standard the design plan specified.
- **Initial-sale long SOW:** unchanged.
- **Upsell short SOW:** previously inlined, now attaches a PDF. Slightly suboptimal — the design plan calls for upsells to inline short SOWs into AWD's `sow` field, but that's Phase 4 work (PR #138 + the registry-driven assembler that replaces this code path entirely). Until Phase 4 ships, all upsells use base/senior + attached PDF, which matches how upsells already worked for long SOWs.
- **Upsell long SOW:** unchanged.

Cost: every draft now generates a PDF (~50-200ms extra for short SOWs). Imperceptible in the agent flow.

## Self-review

- `pnpm tsc --noEmit` clean.
- `pnpm lint` clean (in changed files).
- `pnpm tsx scripts/verify-build-signing-request.ts` — passes.
- No DB schema changes, no env changes, no third-party API changes.
- Independent of PR #138 (the composable-templating scaffolding). Both can land in any order; this hotfix doesn't depend on the registry.

## Test plan

- [ ] Reviewer confirms the behavior change for upsells is acceptable as a temporary state until Phase 4.
- [ ] Post-deploy: tail Vercel logs on the next qstash-jobs invocation, confirm a draft creation succeeds with a PDF attached.
- [ ] Post-deploy: visually inspect the next signed contract — SOW PDF should appear as a separate document in the envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)