### PR TITLE
feat(zoho-sign): registry-driven envelope assembler (Phase 4)

### DIFF
--- a/docs/zoho-sign/template-inventory.md
+++ b/docs/zoho-sign/template-inventory.md
@@ -82,20 +82,23 @@ API capabilities + recipient unification: see [research-notes.md](./research-not
 - **Action IDs:**
   - homeowner: `563034000000079297` (Homeowner-only by design — contractor signer may be added later if needed)
 - **Last verified against Zoho:** 2026-04-28
-- **Fields:**
+- **Fields (12 total):**
 
-  | Field name | Type | Source |
-  |---|---|---|
-  | ho-name | text | `customer.name` |
-  | ho-address | text | `customer.address` |
-  | ho-city-state-zip | text | `${city}, ${state} ${zip}` |
-  | ho-phone | text | `customer.phone` |
-  | ho-email | text | `customer.email` |
-  | sow | text | `sowText` when `!isLongSow`; empty when long (sow-pdf doc carries the content) |
-  | price-adjustment | text | `computeFinalTcp(funding)` — signed amount; positive for added scope, negative for credits/discounts |
-  | sent-date | CustomDate | today (fills via `field_date_data`) |
-  | start-date | CustomDate | today + 3 days (fills via `field_date_data`) |
-  | completion-date | CustomDate | start-date + `validThroughTimeframe` (fills via `field_date_data`) |
+  | Field name | Type | Date format | Source |
+  |---|---|---|---|
+  | ho-name | text | — | `customer.name` |
+  | ho-address | text | — | `customer.address` |
+  | ho-city-state-zip | text | — | `${city}, ${state} ${zip}` |
+  | ho-phone | text | — | `customer.phone` |
+  | ho-email | text | — | `customer.email` |
+  | sow | text | — | `sowText` when `!isLongSow`; empty when long (sow-pdf carries the content) |
+  | price-adjustment | text | — | `computeFinalTcp(funding)` — signed amount; positive for added scope, negative for credits |
+  | sent-date | CustomDate | `MM/dd/yyyy` | today |
+  | start-date | CustomDate | `MMM dd yyyy` | today + 3 days |
+  | completion-date | CustomDate | `MMM dd yyyy` | start-date + `validThroughTimeframe` |
+  | original-contract-date | CustomDate | `MMM dd yyyy` | **TODO (Phase 4.5)** — currently a placeholder of today; agent must edit on the draft before sending. Real source is the project's first-contract `contractSentAt`. |
+
+> **Date format quirk:** AWD's `sent-date` accepts `MM/dd/yyyy` while its other CustomDate fields require `MMM dd yyyy`. Sending the wrong format returns HTTP 400 with `code 8033 — Date format is invalid`. The registry uses two distinct field sources (`sentDateSrc` vs `formatZohoShortDate`-based) to handle this.
 
 ---
 

--- a/scripts/verify-assemble-envelope.ts
+++ b/scripts/verify-assemble-envelope.ts
@@ -1,0 +1,99 @@
+/* eslint-disable no-console */
+/**
+ * End-to-end smoke test for the Phase 4 registry-driven envelope
+ * assembler. Builds a fake ProposalContext (no DB), calls
+ * assembleEnvelope directly, creates a real DRAFT envelope in Zoho.
+ *
+ * Run: pnpm tsx scripts/verify-assemble-envelope.ts <recipient-email>
+ *
+ * The created draft is left in Zoho — clean it up via the Sign UI or
+ * a follow-up DELETE /requests/{id} call.
+ */
+import type { ProposalContext } from '@/shared/services/zoho-sign/documents/types'
+import { assembleEnvelope } from '@/shared/services/zoho-sign/documents/assemble-envelope'
+
+function makeFakeContext(recipientEmail: string): ProposalContext {
+  // Upsell + short SOW + non-senior is the smallest envelope that
+  // exercises the registry-driven path: required = [awd], no
+  // sow-pdf (forbidden when !isLongSow on upsell). Avoids the SOW
+  // PDF generator's DB hit, so the smoke test runs without a real
+  // proposal row.
+  const proposal = {
+    id: 'fake-proposal-phase-4-smoke-test',
+    label: 'Phase 4 smoke test',
+    formMetaJSON: {
+      pricingMode: 'total',
+      envelopeDocumentIds: ['awd'],
+    },
+    projectJSON: {
+      data: {
+        sow: [{
+          contentJSON: JSON.stringify({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Phase 4 smoke-test additional work.' }] }],
+          }),
+          html: '',
+          scopes: [],
+          title: 'Test',
+          trade: { id: 't', label: 'T' },
+        }],
+        validThroughTimeframe: '60 days',
+      },
+    },
+    fundingJSON: {
+      data: { depositAmount: 500, startingTcp: 7500, incentives: [], cashInDeal: 7000 },
+    },
+    customer: {
+      id: 'fake-customer',
+      name: 'Phase 4 Test Customer',
+      phone: '555-0100',
+      email: recipientEmail,
+      address: '123 Phase 4 St',
+      city: 'Anytown',
+      state: 'CA',
+      zip: '90210',
+      customerAge: 45,
+    },
+    meetingProjectId: 'fake-existing-project-uuid',
+  } as unknown as ProposalContext['proposal']
+
+  return {
+    proposal,
+    scenario: 'upsell',
+    isSenior: false,
+    isLongSow: false,
+    finalTcp: 7500,
+    sowText: 'Phase 4 smoke-test additional work.',
+  }
+}
+
+async function main() {
+  const recipientEmail = process.argv[2]
+  if (!recipientEmail) {
+    console.error('Usage: pnpm tsx scripts/verify-assemble-envelope.ts <recipient-email>')
+    process.exit(1)
+  }
+
+  const ctx = makeFakeContext(recipientEmail)
+  console.log('=== assembleEnvelope smoke test ===')
+  console.log(`scenario: ${ctx.scenario}`)
+  console.log(`docs: ${ctx.proposal.formMetaJSON.envelopeDocumentIds?.join(', ')}`)
+  console.log(`recipient: ${recipientEmail}`)
+  console.log()
+
+  const { requestId, status, documentIds } = await assembleEnvelope(ctx)
+  console.log('--- Result ---')
+  console.log(`requestId:    ${requestId}`)
+  console.log(`status:       ${status}`)
+  console.log(`documents:    ${documentIds.join(', ')}`)
+  console.log(`\nLeave the draft alone OR delete via Zoho UI / DELETE /api/v1/requests/${requestId}`)
+  console.log('Inspect the draft in your Zoho dashboard — should show:')
+  console.log('  - 1 document: tpr-additional-work-standalone')
+  console.log('  - 1 envelope-level Homeowner recipient (no Contractor — AWD is homeowner-only)')
+  console.log('  - sow field populated with the SOW text; price-adjustment = 7500')
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err)
+  process.exit(1)
+})

--- a/src/shared/dal/server/proposals/api.ts
+++ b/src/shared/dal/server/proposals/api.ts
@@ -59,6 +59,12 @@ export async function getProposal(proposalId: string) {
         zip: customers.zip,
         customerProfileJSON: customers.customerProfileJSON,
       },
+      // The proposal's meeting's projectId. Null = initial scenario
+      // (no project yet — created on proposal approval per the
+      // project-conversion rule). Non-null = upsell on an existing
+      // project. Drives envelope-scenario derivation in
+      // src/shared/services/zoho-sign/documents/proposal-context.ts.
+      meetingProjectId: meetings.projectId,
     })
     .from(proposals)
     .leftJoin(meetings, eq(meetings.id, proposals.meetingId))

--- a/src/shared/services/contract.service.ts
+++ b/src/shared/services/contract.service.ts
@@ -4,6 +4,8 @@ import { getProposal, updateProposal } from '@/shared/dal/server/proposals/api'
 import { pdfService } from '@/shared/services/pdf.service'
 import { countPdfPages } from '@/shared/services/pdf/count-pdf-pages'
 import { ZOHO_SIGN_BASE_URL } from '@/shared/services/zoho-sign/constants'
+import { assembleEnvelope } from '@/shared/services/zoho-sign/documents/assemble-envelope'
+import { buildProposalContext } from '@/shared/services/zoho-sign/documents/proposal-context'
 import { buildSigningRequest } from '@/shared/services/zoho-sign/lib/build-signing-request'
 import { getZohoAccessToken } from '@/shared/services/zoho-sign/lib/get-access-token'
 
@@ -105,20 +107,27 @@ function createContractService() {
   }
 
   /**
-   * Creates a Zoho Sign draft for a proposal. Always generates a SOW PDF
-   * and attaches it to the envelope.
+   * Creates a Zoho Sign draft for a proposal. Two code paths:
    *
-   * The base + senior HI templates were trimmed (sow-1/sow-2 fields
-   * removed) — every signed contract now reads SOW content from the
-   * attached PDF, regardless of length. The previous short/long branch
-   * (inlining short SOWs into sow-1/sow-2) is dead because those fields
-   * no longer exist on the templates; routing through the inline path
-   * would silently lose the SOW content.
+   * - **Registry path** (when `formMetaJSON.envelopeDocumentIds` is set):
+   *   builds a ProposalContext, validates the agent's selection against
+   *   the scenario rules, calls `assembleEnvelope` which posts to
+   *   `/templates/mergesend` (multi-template envelope) and attaches any
+   *   generated PDFs. The envelope's document set comes from the
+   *   registry; recipient/field unification is automatic via Zoho.
    *
-   * Phase 4 of the composable-templating migration will replace this
-   * with a registry-driven assembler that handles upsells via the AWD
-   * template (where short SOW does inline). Until then, every proposal
-   * — initial or upsell — uses base/senior + attached PDF.
+   * - **Legacy path** (when the proposal has no `envelopeDocumentIds`):
+   *   the pre-Phase-4 flow — single-template `createdocument` against
+   *   base or senior tpr-HI plus an attached SOW PDF. Kept for in-flight
+   *   proposals created before the agent UI shipped; they pass through
+   *   without breaking. New proposals (post-Phase-5) will always carry
+   *   an `envelopeDocumentIds` selection and use the registry path.
+   *
+   * Both paths always generate a SOW PDF — the legacy templates were
+   * trimmed in Zoho (sow-1/sow-2 fields removed), so SOW content lives
+   * exclusively in the attached PDF on this path. See the design plan
+   * (.claude/plans/i-just-confirmed-harmonic-pinwheel.md) for the full
+   * migration shape.
    */
   async function createDraft(proposalId: string, ownerKey: string | null) {
     const proposal = await getProposal(proposalId)
@@ -126,6 +135,15 @@ function createContractService() {
       throw new Error(`Proposal ${proposalId} not found`)
     }
 
+    const selection = proposal.formMetaJSON.envelopeDocumentIds ?? []
+    if (selection.length > 0) {
+      const ctx = buildProposalContext(proposal)
+      const { requestId, status } = await assembleEnvelope(ctx)
+      await updateProposal(ownerKey, proposalId, { signingRequestId: requestId })
+      return { requestId, status }
+    }
+
+    // Legacy path: pre-Phase-5 proposals without an envelope-document selection.
     const pdfBuffer = await pdfService.generateSowPdf({ proposalId })
     const sowPages = await countPdfPages(pdfBuffer)
     const { templateId, body } = buildSigningRequest(proposal, { sowPages })

--- a/src/shared/services/zoho-sign/documents/assemble-envelope.ts
+++ b/src/shared/services/zoho-sign/documents/assemble-envelope.ts
@@ -1,0 +1,227 @@
+import type { Buffer } from 'node:buffer'
+import type { EnvelopeDocument, ProposalContext } from './types'
+import type { EnvelopeDocumentId } from '@/shared/constants/enums'
+import { ZOHO_SIGN_BASE_URL } from '../constants'
+import { getZohoAccessToken } from '../lib/get-access-token'
+import { validateEnvelopeSelection } from './evaluate'
+import { ENVELOPE_DOCUMENTS } from './registry'
+
+interface ZohoMergeSendResponse {
+  code?: number
+  status?: string
+  requests?: {
+    request_id: string
+    request_status: string
+  }
+}
+
+interface AttachFile {
+  name: string
+  buffer: Buffer
+  mime: string
+}
+
+interface AssembleResult {
+  requestId: string
+  status: string
+  documentIds: EnvelopeDocumentId[]
+}
+
+/**
+ * Builds and submits a Zoho Sign envelope from the agent-selected
+ * documents. Each selected zoho-template document contributes its
+ * fields + signer action_ids; each generated-pdf document is rendered
+ * to a buffer and attached after the envelope is created.
+ *
+ * Recipient unification is automatic — listing the same email under
+ * multiple template-level action_ids collapses to one envelope-level
+ * recipient (verified in Phase 1's smoke tests). Field data is global
+ * per envelope: identical labels across templates fill once.
+ *
+ * Throws on invalid selection (missing required / forbidden present)
+ * via validateEnvelopeSelection. On Zoho API failure, attempts cleanup
+ * via deleteRequest before rethrowing so the QStash retry isn't stuck
+ * with a half-built envelope.
+ */
+export async function assembleEnvelope(ctx: ProposalContext): Promise<AssembleResult> {
+  const selection = ctx.proposal.formMetaJSON.envelopeDocumentIds ?? []
+  validateEnvelopeSelection(ctx, selection)
+
+  // Canonicalize order against the registry — agent-submitted order is
+  // ignored; envelope documents render in the registry's declared order.
+  const orderedDocs = ENVELOPE_DOCUMENTS.filter(d => selection.includes(d.id))
+  const templateDocs = orderedDocs.filter(d => d.source.kind === 'zoho-template')
+  const pdfDocs = orderedDocs.filter(d => d.source.kind === 'generated-pdf')
+
+  if (templateDocs.length === 0) {
+    throw new Error('assembleEnvelope: at least one zoho-template document is required (cannot build an envelope from PDFs alone)')
+  }
+
+  const token = await getZohoAccessToken()
+
+  // Step 1: mergesend creates a multi-template envelope and returns one
+  // request_id. POST /api/v1/templates/mergesend (form-urlencoded):
+  // template_ids=[...]&data={...}&is_quicksend=false. See
+  // docs/zoho-sign/research-notes.md for the full API shape.
+  const mergeBody = buildMergeSendBody(ctx, templateDocs)
+  const mergeRes = await fetch(`${ZOHO_SIGN_BASE_URL}/api/v1/templates/mergesend`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Zoho-oauthtoken ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: mergeBody,
+  })
+  if (!mergeRes.ok) {
+    throw new Error(`Zoho mergesend failed (${mergeRes.status}): ${await mergeRes.text()}`)
+  }
+  const mergeJson = (await mergeRes.json()) as ZohoMergeSendResponse
+  const requestId = mergeJson.requests?.request_id
+  if (!requestId) {
+    throw new Error(`Zoho mergesend returned no request_id: ${JSON.stringify(mergeJson)}`)
+  }
+
+  // Step 2: attach each generated PDF. Failure here leaves the envelope
+  // half-built — delete and let the next QStash retry create fresh.
+  if (pdfDocs.length > 0) {
+    try {
+      const files: AttachFile[] = []
+      for (const doc of pdfDocs) {
+        if (doc.source.kind !== 'generated-pdf') {
+          continue
+        }
+        const buffer = await doc.source.generator(ctx)
+        files.push({
+          name: sanitizeFilename(`${doc.id}-${ctx.proposal.label || ctx.proposal.id}.pdf`),
+          buffer,
+          mime: 'application/pdf',
+        })
+      }
+      await attachFiles(token, requestId, files)
+    }
+    catch (attachErr) {
+      await deleteRequest(token, requestId).catch(() => {})
+      throw attachErr
+    }
+  }
+
+  return {
+    requestId,
+    status: mergeJson.requests?.request_status ?? 'draft',
+    documentIds: orderedDocs.map(d => d.id),
+  }
+}
+
+/**
+ * Builds the form-urlencoded body for POST /templates/mergesend.
+ * Field data is global per envelope (flat field_text_data /
+ * field_date_data), so identical labels across templates fill once.
+ */
+function buildMergeSendBody(ctx: ProposalContext, templateDocs: readonly EnvelopeDocument[]): string {
+  const templateIds: string[] = []
+  const textData: Record<string, string> = {}
+  const dateData: Record<string, string> = {}
+  const actions: Record<string, unknown>[] = []
+
+  const customerName = ctx.proposal.customer?.name ?? ''
+  const customerEmail = ctx.proposal.customer?.email ?? ''
+
+  for (const doc of templateDocs) {
+    if (doc.source.kind !== 'zoho-template') {
+      continue
+    }
+    templateIds.push(doc.source.zohoTemplateId)
+
+    if (doc.fieldMappings) {
+      for (const [field, source] of Object.entries(doc.fieldMappings)) {
+        textData[field] = source(ctx)
+      }
+    }
+    if (doc.dateFieldMappings) {
+      for (const [field, source] of Object.entries(doc.dateFieldMappings)) {
+        dateData[field] = source(ctx)
+      }
+    }
+
+    if (doc.signerActions?.contractor) {
+      actions.push({
+        recipient_name: 'Tri Pros Remodeling',
+        recipient_email: 'info@triprosremodeling.com',
+        action_id: doc.signerActions.contractor,
+        action_type: 'SIGN',
+        signing_order: 1,
+        role: 'Contractor',
+        verify_recipient: false,
+        private_notes: '',
+      })
+    }
+    if (doc.signerActions?.homeowner) {
+      actions.push({
+        recipient_name: customerName,
+        recipient_email: customerEmail,
+        action_id: doc.signerActions.homeowner,
+        action_type: 'SIGN',
+        signing_order: 2,
+        role: 'Homeowner',
+        verify_recipient: true,
+        verification_type: 'EMAIL',
+        private_notes: '',
+      })
+    }
+  }
+
+  const data = {
+    templates: {
+      field_data: {
+        field_text_data: textData,
+        field_boolean_data: {},
+        field_date_data: dateData,
+        field_radio_data: {},
+      },
+      actions,
+      notes: '',
+    },
+  }
+
+  const body = new URLSearchParams()
+  body.set('template_ids', JSON.stringify(templateIds))
+  body.set('data', JSON.stringify(data))
+  body.set('is_quicksend', 'false')
+  return body.toString()
+}
+
+/** Multipart attach via PUT /requests/{id}. Mirrors contract.service.ts addFilesToRequest. */
+async function attachFiles(token: string, requestId: string, files: AttachFile[]): Promise<void> {
+  if (files.length === 0) {
+    return
+  }
+  const form = new FormData()
+  form.append('data', JSON.stringify({ requests: {} }))
+  for (const f of files) {
+    form.append('file', new Blob([new Uint8Array(f.buffer)], { type: f.mime }), f.name)
+  }
+  const res = await fetch(`${ZOHO_SIGN_BASE_URL}/api/v1/requests/${requestId}`, {
+    method: 'PUT',
+    headers: { Authorization: `Zoho-oauthtoken ${token}` },
+    body: form,
+  })
+  if (!res.ok) {
+    throw new Error(`Zoho addFilesToRequest failed (${res.status}): ${await res.text()}`)
+  }
+}
+
+/** Recall + delete. Best-effort cleanup on attach failure. */
+async function deleteRequest(token: string, requestId: string): Promise<void> {
+  await fetch(`${ZOHO_SIGN_BASE_URL}/api/v1/requests/${requestId}/delete`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Zoho-oauthtoken ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ recall_inprogress: true }),
+  })
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/]/g, '_').replace(/\s+/g, '_').slice(0, 200)
+}

--- a/src/shared/services/zoho-sign/documents/proposal-context.ts
+++ b/src/shared/services/zoho-sign/documents/proposal-context.ts
@@ -6,24 +6,19 @@ import { computeFinalTcp } from '@/shared/entities/proposals/lib/compute-final-t
 import { sowToPlaintext } from '@/shared/lib/tiptap-to-text'
 import { isLongSow } from '../lib/is-long-sow'
 
-interface BuildContextInput {
-  proposal: ProposalWithCustomer
-  /**
-   * The proposal's meeting's projectId. `null` = initial sale (project
-   * will be created if proposal is approved). Non-null = upsell on an
-   * existing project. Caller is responsible for fetching this — keeps
-   * the builder pure.
-   */
-  meetingProjectId: string | null
-}
-
 /**
  * Builds the snapshot all envelope-document predicates and field
  * sources resolve against. Pure: same input, same output, no I/O. Built
  * once per draft creation; passed through to evaluator + assembler.
+ *
+ * Scenario is derived from the proposal's meeting's projectId — null
+ * means initial sale (a new project will be created if the proposal
+ * is approved); non-null means upsell on an existing project. The
+ * meeting-projectId join lives in the DAL's getProposal so callers
+ * don't need to fetch it separately.
  */
-export function buildProposalContext({ proposal, meetingProjectId }: BuildContextInput): ProposalContext {
-  const scenario: EnvelopeScenario = meetingProjectId !== null ? 'upsell' : 'initial'
+export function buildProposalContext(proposal: ProposalWithCustomer): ProposalContext {
+  const scenario: EnvelopeScenario = proposal.meetingProjectId !== null ? 'upsell' : 'initial'
   const sowText = sowToPlaintext(proposal.projectJSON.data.sow ?? [])
   return {
     proposal,

--- a/src/shared/services/zoho-sign/documents/registry.ts
+++ b/src/shared/services/zoho-sign/documents/registry.ts
@@ -26,20 +26,61 @@ const customerAgeSrc: FieldSource = ctx => String(ctx.proposal.customer?.custome
 const tcpSrc: FieldSource = ctx => String(ctx.finalTcp)
 const depositSrc: FieldSource = ctx => String(ctx.proposal.fundingJSON.data.depositAmount)
 
-const startDateSrc: FieldSource = () => {
+// Zoho's CustomDate fields validate against the template's date_format.
+// AWD's start-date / completion-date / original-contract-date are
+// configured as `MMM dd yyyy` (e.g. "Apr 28 2026"). The base / senior
+// templates use plain Textfield dates so they accept any printable
+// string — those keep using toLocaleDateString. Use the *ZohoSrc
+// variants when targeting a CustomDate field.
+const ZOHO_SHORT_DATE_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const
+function formatZohoShortDate(date: Date): string {
+  const month = ZOHO_SHORT_DATE_MONTHS[date.getMonth()]
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${month} ${day} ${date.getFullYear()}`
+}
+
+const startDateTextSrc: FieldSource = () => {
   const d = new Date()
   d.setDate(d.getDate() + 3)
   return d.toLocaleDateString('en-US')
 }
 
-const completionDateSrc: FieldSource = (ctx) => {
+const completionDateTextSrc: FieldSource = (ctx) => {
   const days = Number(ctx.proposal.projectJSON.data.validThroughTimeframe.replace(/\D/g, ''))
   const d = new Date()
   d.setDate(d.getDate() + 3 + days)
   return d.toLocaleDateString('en-US')
 }
 
-const todaySrc: FieldSource = () => new Date().toLocaleDateString('en-US')
+const startDateZohoSrc: FieldSource = () => {
+  const d = new Date()
+  d.setDate(d.getDate() + 3)
+  return formatZohoShortDate(d)
+}
+
+const completionDateZohoSrc: FieldSource = (ctx) => {
+  const days = Number(ctx.proposal.projectJSON.data.validThroughTimeframe.replace(/\D/g, ''))
+  const d = new Date()
+  d.setDate(d.getDate() + 3 + days)
+  return formatZohoShortDate(d)
+}
+
+// Zoho per-template date format quirk: every template's `sent-date`
+// field is configured with date_format `MM/dd/yyyy` (verified via real
+// mergesend). AWD's `start-date` / `completion-date` /
+// `original-contract-date` use `MMM dd yyyy`. Other templates'
+// start/completion fields are plain Textfield and accept any printable
+// string. Keep this in sync with the inventory artifact.
+const sentDateSrc: FieldSource = () => new Date().toLocaleDateString('en-US')
+
+// AWD's original-contract-date refers to when the PROJECT'S original
+// contract was signed (not the upsell proposal's creation). The true
+// source is project-level data — the project's first proposal's
+// contractSentAt. Until project lookup lands in proposal-context.ts
+// (Phase 4.5 follow-up), we fall back to today as a placeholder so the
+// envelope creates successfully. The agent must edit this field on the
+// draft before sending.
+const originalContractDatePlaceholderSrc: FieldSource = () => formatZohoShortDate(new Date())
 
 const baseHomeownerFieldMappings: Record<string, FieldSource> = {
   'ho-name': customerNameSrc,
@@ -81,12 +122,13 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
     fieldMappings: {
       ...baseHomeownerFieldMappings,
       'ho-age': customerAgeSrc,
-      'start-date': startDateSrc,
-      'completion-date': completionDateSrc,
+      'start-date': startDateTextSrc,
+      'completion-date': completionDateTextSrc,
       'tcp': tcpSrc,
       'deposit': depositSrc,
-      // sow-1 / sow-2 stay on the template until the user trims it. Filled
-      // through the legacy build-signing-request.ts path until Phase 4.
+      // sow-1 / sow-2 trimmed in Zoho UI 2026-04-28 — base / senior templates
+      // no longer have those fields. SOW content lives in the attached
+      // sow-pdf doc, not here.
     },
     signerActions: ZOHO_SIGN_TEMPLATES.base.actions,
   },
@@ -101,8 +143,8 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
     fieldMappings: {
       ...baseHomeownerFieldMappings,
       'ho-age': customerAgeSrc,
-      'start-date': startDateSrc,
-      'completion-date': completionDateSrc,
+      'start-date': startDateTextSrc,
+      'completion-date': completionDateTextSrc,
       'tcp': tcpSrc,
       'deposit': depositSrc,
     },
@@ -145,9 +187,10 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
       'price-adjustment': tcpSrc,
     },
     dateFieldMappings: {
-      'sent-date': todaySrc,
-      'start-date': startDateSrc,
-      'completion-date': completionDateSrc,
+      'sent-date': sentDateSrc,
+      'start-date': startDateZohoSrc,
+      'completion-date': completionDateZohoSrc,
+      'original-contract-date': originalContractDatePlaceholderSrc,
     },
     signerActions: ZOHO_SIGN_TEMPLATES.awd.actions,
   },
@@ -164,7 +207,7 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
       'ho-age': customerAgeSrc,
     },
     dateFieldMappings: {
-      'sent-date': todaySrc,
+      'sent-date': sentDateSrc,
     },
     signerActions: ZOHO_SIGN_TEMPLATES.seniorAck.actions,
   },
@@ -180,7 +223,7 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
       ...baseHomeownerFieldMappings,
     },
     dateFieldMappings: {
-      'sent-date': todaySrc,
+      'sent-date': sentDateSrc,
     },
     signerActions: ZOHO_SIGN_TEMPLATES.esignWaiver.actions,
   },
@@ -200,7 +243,7 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
       // mirror the customer's material list once that data model exists.
     },
     dateFieldMappings: {
-      'sent-date': todaySrc,
+      'sent-date': sentDateSrc,
     },
     signerActions: ZOHO_SIGN_TEMPLATES.materialOrder.actions,
   },


### PR DESCRIPTION
## Summary

Wires the Phase 2 registry into `contract.service.ts` via a new `assembleEnvelope()` that posts to `POST /templates/mergesend` (Zoho's multi-template envelope endpoint, confirmed in Phase 1 research). Smoke-verified against real Zoho — request_id `563034000000080115` left in the dashboard for visual inspection.

**No behavior change for in-flight proposals.** `contract.service.ts createDraft` branches:
- **Registry path** (when `proposal.formMetaJSON.envelopeDocumentIds` is set): builds `ProposalContext`, validates selection, calls `assembleEnvelope`, attaches any generated PDFs.
- **Legacy path** (empty / null `envelopeDocumentIds`): the pre-Phase-4 single-template + attached PDF flow. Pre-existing proposals keep working unchanged.

Once Phase 5 (agent UI) ships, every new proposal carries an `envelopeDocumentIds` selection and flows through the registry path. Legacy fallback removed in Phase 6 cleanup.

## What's in this PR

- **[src/shared/services/zoho-sign/documents/assemble-envelope.ts](https://github.com/OlisDevSpot/tri-pros-website/pull/140/files)** (new) — partitions docs by source, iterates `fieldMappings` + `dateFieldMappings` + `signerActions`, builds the form-urlencoded mergesend body, attaches generated PDFs via the existing `addFilesToRequest` pattern. Cleans up the draft on attach failure so QStash retries don't inherit half-built envelopes.
- **[`src/shared/services/zoho-sign/documents/registry.ts`](https://github.com/OlisDevSpot/tri-pros-website/pull/140/files)** — adds `formatZohoShortDate` helper (`MMM dd yyyy`) for AWD's CustomDate fields. Sent-date stays on `MM/dd/yyyy` (per template config — see "Date format quirk" below). New `original-contract-date` field added with a TODO placeholder source (Phase 4.5 follow-up).
- **`src/shared/dal/server/proposals/api.ts`** — one-column join: `getProposal` now returns `meetingProjectId`. Powers scenario derivation in `proposal-context.ts` without an extra query.
- **`src/shared/services/zoho-sign/documents/proposal-context.ts`** — reads `meetingProjectId` directly off `ProposalWithCustomer`. No more explicit caller-supplied parameter.
- **`src/shared/services/contract.service.ts`** — `createDraft` becomes a 2-path dispatcher with the legacy fallback for in-flight proposals.
- **`scripts/verify-assemble-envelope.ts`** (new) — end-to-end smoke test against real Zoho. Builds a fake upsell `ProposalContext` (avoids DB / SOW PDF generator), creates a draft, prints inspection notes.
- **[`docs/zoho-sign/template-inventory.md`](https://github.com/OlisDevSpot/tri-pros-website/pull/140/files)** — AWD entry refreshed: 12 fields, per-field `Date format` column, the date-quirk callout, `original-contract-date` documented as TODO.

## Date format quirk (worth knowing)

Discovered empirically during smoke testing: Zoho's CustomDate fields validate against the template's configured `date_format`. **AWD has TWO different formats on different fields**:

| Field | Format |
|---|---|
| `sent-date` | `MM/dd/yyyy` |
| `start-date`, `completion-date`, `original-contract-date` | `MMM dd yyyy` (e.g. "Apr 28 2026") |

Sending the wrong format returns HTTP 400 with `code 8033 — Date format is invalid`. The registry uses two distinct field sources to handle this. Documented in the inventory artifact's quirk note.

## TODO (Phase 4.5)

- `original-contract-date` is currently sourced as a placeholder (today's date). Real source is the project's first-contract `contractSentAt` — needs project lookup wired into `proposal-context.ts`. Until then, the agent must edit this field on the draft before sending. AWD envelopes WILL create successfully — just with a misleading date until the agent fixes it.

## Self-review

- `pnpm tsc --noEmit` clean.
- `pnpm lint` clean (in changed files; pre-existing warnings elsewhere unchanged).
- `verify-evaluate-documents.ts`: 7 fixtures + 4 validator guards — all green.
- `verify-build-signing-request.ts`: post-trim shape — all green.
- `verify-assemble-envelope.ts`: real Zoho draft via registry path — created `563034000000080115` (visible in dashboard).
- No DB schema changes. New column on the `getProposal` SELECT but no migration needed.
- Independent of any other in-flight PR.

## Test plan

- [ ] Reviewer confirms the legacy fallback wraps in-flight proposals correctly (any proposal without `envelopeDocumentIds` continues to work via the legacy path).
- [ ] Reviewer agrees `original-contract-date` placeholder is acceptable as a temporary state until Phase 4.5.
- [ ] Post-deploy: tail Vercel logs on the next qstash-jobs invocation. Confirm draft creation succeeds for an in-flight proposal (legacy path).
- [ ] Optional: in a dev session, manually set `formMetaJSON.envelopeDocumentIds` on a real test proposal and confirm the registry path creates a multi-template envelope correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)