### PR TITLE
feat(zoho-sign): agent draft-config UI for envelope documents (Phase 5)

### DIFF
--- a/src/features/proposal-flow/ui/components/proposal/index.tsx
+++ b/src/features/proposal-flow/ui/components/proposal/index.tsx
@@ -101,6 +101,7 @@ export function Proposal() {
                     isAgent={ability.can('update', 'Proposal')}
                     customerAge={customer?.customerAge ?? null}
                     customerId={customer?.id ?? null}
+                    envelopeDocumentIds={proposal.data.formMetaJSON?.envelopeDocumentIds ?? null}
                     proposalStatus={proposal.data.status}
                     proposalSentAt={proposal.data.sentAt}
                     isSendingEmail={sendProposalEmail.isPending}

--- a/src/shared/components/contract-status-panel/types.ts
+++ b/src/shared/components/contract-status-panel/types.ts
@@ -1,3 +1,5 @@
+import type { EnvelopeDocumentId } from '@/shared/constants/enums'
+
 export interface ContractStatusPanelProps {
   proposalId: string
   token?: string
@@ -5,6 +7,11 @@ export interface ContractStatusPanelProps {
   isAgent: boolean
   customerAge?: number | null
   customerId?: string | null
+  /**
+   * Agent-picked envelope document selection from `formMetaJSON`.
+   * Null = not yet configured (gates the agent draft-config form).
+   */
+  envelopeDocumentIds?: readonly EnvelopeDocumentId[] | null
   onSendProposalEmail?: (message: string) => void
   isSendingEmail?: boolean
   proposalStatus?: string

--- a/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { EnvelopeDocumentId } from '@/shared/constants/enums'
 import type { ZohoActionStatus, ZohoContractStatus } from '@/shared/services/zoho-sign/types'
 import { useMutation } from '@tanstack/react-query'
 import { CheckCircle, Eye, Loader2, Mail, Minus, RefreshCw, Send, Trash2 } from 'lucide-react'
@@ -14,7 +15,7 @@ import { cn } from '@/shared/lib/utils'
 import { useTRPC } from '@/trpc/helpers'
 import { ACTION_TOOLTIPS } from '../constants/contract-statuses'
 import { useCreditCooldown } from '../hooks/use-credit-cooldown'
-import { CustomerAgeForm } from './customer-age-form'
+import { AgentDraftConfigurationForm } from './agent-draft-configuration-form'
 import { ResendConfirmDialog } from './resend-confirm-dialog'
 
 interface AgentContractViewProps {
@@ -22,6 +23,7 @@ interface AgentContractViewProps {
   contractStatus: (ZohoContractStatus & { contractSentAt: string | null }) | null
   customerAge: number | null
   customerId: string | null
+  envelopeDocumentIds: readonly EnvelopeDocumentId[] | null
   onSendProposalEmail?: (message: string) => void
   isSendingEmail?: boolean
   proposalStatus?: string
@@ -66,6 +68,7 @@ export function AgentContractView({
   proposalId,
   contractStatus,
   customerAge,
+  envelopeDocumentIds,
   onSendProposalEmail,
   isSendingEmail,
   proposalStatus,
@@ -154,18 +157,23 @@ export function AgentContractView({
             )}
           </div>
 
-          {/* Age gate — must be set before any contract actions */}
-          {customerAge == null && (
-            <CustomerAgeForm proposalId={proposalId} />
+          {/* Draft-config gate — both age AND envelope document selection
+              must be set before any contract actions. The form persists
+              both atomically via configureDraftEnvelope. */}
+          {!contractStatus && (customerAge == null || envelopeDocumentIds == null) && (
+            <AgentDraftConfigurationForm
+              proposalId={proposalId}
+              initialAge={customerAge}
+            />
           )}
 
           {/* State: Draft is being created by background job */}
-          {!contractStatus && isDraftSyncing && customerAge != null && (
+          {!contractStatus && isDraftSyncing && customerAge != null && envelopeDocumentIds != null && (
             <DraftSyncingState />
           )}
 
-          {/* State: No contract yet (age must be set) */}
-          {!contractStatus && !isDraftSyncing && customerAge != null && (
+          {/* State: No contract yet (age + docs must be set) */}
+          {!contractStatus && !isDraftSyncing && customerAge != null && envelopeDocumentIds != null && (
             <NoContractState
               isSent={isSent}
               isSendingEmail={isSendingEmail ?? false}

--- a/src/shared/components/contract-status-panel/ui/agent-draft-configuration-form.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-draft-configuration-form.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import type { EnvelopeDocumentId } from '@/shared/constants/enums'
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query'
+import { Check, Loader2, ShieldCheck } from 'lucide-react'
+import { motion } from 'motion/react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/shared/components/ui/button'
+import { Input } from '@/shared/components/ui/input'
+import { Switch } from '@/shared/components/ui/switch'
+import { useInvalidation } from '@/shared/dal/client/use-invalidation'
+import { cn } from '@/shared/lib/utils'
+import { useTRPC } from '@/trpc/helpers'
+
+interface AgentDraftConfigurationFormProps {
+  proposalId: string
+  /** Customer's currently saved age. Pre-fills the input if present. */
+  initialAge: number | null
+}
+
+/**
+ * Pre-send draft configuration for the agent. Two stages, single submit:
+ *
+ *   1. Customer age — drives senior-vs-non-senior agreement variant
+ *      and reveals the document selector once valid.
+ *   2. Document selector — required docs render as static check rows
+ *      (cannot be unchecked), optional docs render as Switches that
+ *      default off. List comes from the registry-driven evaluator.
+ *
+ * Submitting fires `configureDraftEnvelope`, which atomically persists
+ * both the age and the selection. The send-proposal flow then picks up
+ * the registry path and assembles the envelope from the chosen docs.
+ */
+export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDraftConfigurationFormProps) {
+  const trpc = useTRPC()
+  const { invalidateProposal } = useInvalidation()
+
+  const [ageInput, setAgeInput] = useState(initialAge != null ? String(initialAge) : '')
+  // Raw selection — may contain ids that are no longer applicable when
+  // senior status flips. The derived `validSelected` below intersects
+  // against the current evaluation, so stale entries never leak into
+  // either the rendered switches or the submitted payload.
+  const [optionalSelected, setOptionalSelected] = useState<Set<EnvelopeDocumentId>>(() => new Set())
+
+  const parsedAge = Number.parseInt(ageInput, 10)
+  const isAgeValid = !Number.isNaN(parsedAge) && parsedAge >= 18 && parsedAge <= 120
+
+  const evaluation = useQuery(
+    trpc.proposalsRouter.contracts.evaluateEnvelopeDocs.queryOptions(
+      { proposalId, ageOverride: isAgeValid ? parsedAge : undefined },
+      { enabled: isAgeValid, placeholderData: keepPreviousData },
+    ),
+  )
+
+  const submit = useMutation(
+    trpc.proposalsRouter.contracts.configureDraftEnvelope.mutationOptions({
+      onSuccess: () => {
+        invalidateProposal()
+        toast.success('Draft configured')
+      },
+      onError: (err) => {
+        toast.error(err.message || 'Failed to configure draft')
+      },
+    }),
+  )
+
+  const requiredDocs = useMemo(
+    () => evaluation.data?.docs.filter(d => d.status === 'required') ?? [],
+    [evaluation.data],
+  )
+  const optionalDocs = useMemo(
+    () => evaluation.data?.docs.filter(d => d.status === 'optional') ?? [],
+    [evaluation.data],
+  )
+
+  // Derived effective selection — drops any ids that are no longer
+  // optional under the current evaluation (e.g. agent edited age, the
+  // senior branch flipped, a doc switched between optional/forbidden).
+  const validSelected = useMemo<Set<EnvelopeDocumentId>>(() => {
+    const allowed = new Set(optionalDocs.map(d => d.id))
+    const next = new Set<EnvelopeDocumentId>()
+    for (const id of optionalSelected) {
+      if (allowed.has(id)) {
+        next.add(id)
+      }
+    }
+    return next
+  }, [optionalSelected, optionalDocs])
+
+  function handleSubmit() {
+    if (!isAgeValid || !evaluation.data) {
+      return
+    }
+    const selection = [
+      ...requiredDocs.map(d => d.id),
+      ...optionalDocs.filter(d => validSelected.has(d.id)).map(d => d.id),
+    ]
+    submit.mutate({ proposalId, age: parsedAge, envelopeDocumentIds: selection })
+  }
+
+  function toggleOptional(id: EnvelopeDocumentId, checked: boolean) {
+    setOptionalSelected((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(id)
+      }
+      else {
+        next.delete(id)
+      }
+      return next
+    })
+  }
+
+  const showDocs = isAgeValid && evaluation.data != null
+  const isPending = submit.isPending
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex flex-col gap-5 rounded-lg border border-primary/20 bg-primary/5 p-4"
+    >
+      <div className="flex items-start gap-2.5">
+        <ShieldCheck className="mt-0.5 size-4 shrink-0 text-primary" />
+        <div>
+          <p className="text-sm font-medium text-foreground">Configure agreement before sending</p>
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+            Confirm the customer's age and pick which documents this envelope should
+            include. Senior customers (65+) get an additional 5-day cancellation window
+            and the senior-citizen acknowledgement per CSLB rules.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <div className="w-24">
+          <label htmlFor="customer-age" className="mb-1 block text-xs font-medium text-muted-foreground">
+            Age
+          </label>
+          <Input
+            id="customer-age"
+            type="number"
+            min={18}
+            max={120}
+            placeholder="e.g. 42"
+            value={ageInput}
+            onChange={e => setAgeInput(e.target.value)}
+            disabled={isPending}
+          />
+        </div>
+        {isAgeValid && evaluation.data?.isSenior && (
+          <p className="pb-2 text-xs font-medium text-amber-700 dark:text-amber-400">
+            Senior — extended cancellation rights apply
+          </p>
+        )}
+      </div>
+
+      {showDocs && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          className="overflow-hidden"
+        >
+          <div className="border-t border-primary/15 pt-4">
+            <p className="text-xs font-medium text-muted-foreground">Documents in this envelope</p>
+            <div className="mt-2 flex flex-col gap-1.5">
+              {requiredDocs.map(doc => (
+                <RequiredRow key={doc.id} label={doc.label} />
+              ))}
+              {optionalDocs.map(doc => (
+                <OptionalRow
+                  key={doc.id}
+                  id={doc.id}
+                  label={doc.label}
+                  checked={validSelected.has(doc.id)}
+                  disabled={isPending}
+                  onChange={checked => toggleOptional(doc.id, checked)}
+                />
+              ))}
+            </div>
+          </div>
+        </motion.div>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={!showDocs || isPending}
+        size="sm"
+        className="self-end"
+      >
+        {isPending
+          ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Saving...
+              </>
+            )
+          : 'Confirm & Continue'}
+      </Button>
+    </motion.div>
+  )
+}
+
+function RequiredRow({ label }: { label: string }) {
+  return (
+    <div className={cn(
+      'flex items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2',
+    )}
+    >
+      <div className="flex items-center gap-2">
+        <Check className="size-4 text-primary" />
+        <span className="text-sm">{label}</span>
+      </div>
+      <span className="text-xs text-muted-foreground">Required</span>
+    </div>
+  )
+}
+
+function OptionalRow({
+  id,
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: EnvelopeDocumentId
+  label: string
+  checked: boolean
+  disabled: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <label
+      htmlFor={`opt-${id}`}
+      className="flex cursor-pointer items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2 hover:border-border"
+    >
+      <span className="text-sm">{label}</span>
+      <Switch
+        id={`opt-${id}`}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onChange}
+      />
+    </label>
+  )
+}

--- a/src/shared/components/contract-status-panel/ui/contract-status-panel.tsx
+++ b/src/shared/components/contract-status-panel/ui/contract-status-panel.tsx
@@ -12,6 +12,7 @@ export function ContractStatusPanel({
   isAgent,
   customerAge,
   customerId,
+  envelopeDocumentIds,
   onSendProposalEmail,
   isSendingEmail,
   proposalStatus,
@@ -36,6 +37,7 @@ export function ContractStatusPanel({
         contractStatus={contractStatus ?? null}
         customerAge={customerAge ?? null}
         customerId={customerId ?? null}
+        envelopeDocumentIds={envelopeDocumentIds ?? null}
         onSendProposalEmail={onSendProposalEmail}
         isSendingEmail={isSendingEmail}
         proposalStatus={proposalStatus}

--- a/src/shared/services/contract.service.ts
+++ b/src/shared/services/contract.service.ts
@@ -16,6 +16,35 @@ interface ZohoCreateDocResponse {
   }
 }
 
+/**
+ * Zoho returns one `actions` entry per (template × signer-role × recipient).
+ * For a multi-template envelope where the homeowner signs N templates,
+ * that's N entries with role=Homeowner and the same email — which both
+ * collides on the React `key` in the UI grid AND looks wrong (one row per
+ * template). Collapse by `(role, recipientEmail)` and pick the lowest
+ * status across the group: the signer hasn't truly progressed past the
+ * least-advanced template, so we surface that.
+ */
+const ACTION_STATUS_RANK: Record<ZohoActionStatus, number> = {
+  NOACTION: 0,
+  UNOPENED: 1,
+  VIEWED: 2,
+  SIGNED: 3,
+}
+
+function dedupeSignerStatuses(actions: { role: string, action_status: string, recipient_email: string }[]) {
+  const grouped = new Map<string, { role: string, status: ZohoActionStatus, recipientEmail: string }>()
+  for (const a of actions) {
+    const key = `${a.role}::${a.recipient_email}`
+    const status = a.action_status as ZohoActionStatus
+    const existing = grouped.get(key)
+    if (!existing || ACTION_STATUS_RANK[status] < ACTION_STATUS_RANK[existing.status]) {
+      grouped.set(key, { role: a.role, status, recipientEmail: a.recipient_email })
+    }
+  }
+  return Array.from(grouped.values())
+}
+
 function createContractService() {
   async function getAuthHeader() {
     const token = await getZohoAccessToken()
@@ -329,11 +358,7 @@ function createContractService() {
       return {
         requestId: req.request_id,
         requestStatus: req.request_status as ZohoRequestStatus,
-        signerStatuses: req.actions.map(a => ({
-          role: a.role,
-          status: a.action_status as ZohoActionStatus,
-          recipientEmail: a.recipient_email,
-        })),
+        signerStatuses: dedupeSignerStatuses(req.actions),
       }
     },
   }

--- a/src/shared/services/zoho-sign/documents/proposal-context.ts
+++ b/src/shared/services/zoho-sign/documents/proposal-context.ts
@@ -16,14 +16,24 @@ import { isLongSow } from '../lib/is-long-sow'
  * is approved); non-null means upsell on an existing project. The
  * meeting-projectId join lives in the DAL's getProposal so callers
  * don't need to fetch it separately.
+ *
+ * `ageOverride` lets the agent UI preview rule evaluation against an
+ * age the user is currently typing — before that value is persisted to
+ * the customer record. The override only feeds `isSenior`; field
+ * sources still resolve `ho-age` from `customer.customerAge`, so this
+ * never affects the actual values that ship to Zoho.
  */
-export function buildProposalContext(proposal: ProposalWithCustomer): ProposalContext {
+export function buildProposalContext(
+  proposal: ProposalWithCustomer,
+  options: { ageOverride?: number } = {},
+): ProposalContext {
   const scenario: EnvelopeScenario = proposal.meetingProjectId !== null ? 'upsell' : 'initial'
   const sowText = sowToPlaintext(proposal.projectJSON.data.sow ?? [])
+  const ageForSeniorCheck = options.ageOverride ?? proposal.customer?.customerAge
   return {
     proposal,
     scenario,
-    isSenior: isSeniorByAge(proposal.customer?.customerAge),
+    isSenior: isSeniorByAge(ageForSeniorCheck),
     isLongSow: isLongSow(sowText),
     finalTcp: computeFinalTcp(proposal.fundingJSON.data),
     sowText,

--- a/src/trpc/routers/proposals.router/contracts.router.ts
+++ b/src/trpc/routers/proposals.router/contracts.router.ts
@@ -1,11 +1,16 @@
 import { TRPCError } from '@trpc/server'
 import { eq } from 'drizzle-orm'
 import z from 'zod'
+import { envelopeDocumentIds } from '@/shared/constants/enums'
 import { getProposal } from '@/shared/dal/server/proposals/api'
 import { db } from '@/shared/db'
 import { customers } from '@/shared/db/schema/customers'
+import { proposals } from '@/shared/db/schema/proposals'
 import { defineAbilitiesFor } from '@/shared/domains/permissions/abilities'
 import { contractService } from '@/shared/services/contract.service'
+import { EnvelopeSelectionError, evaluateDocuments, validateEnvelopeSelection } from '@/shared/services/zoho-sign/documents/evaluate'
+import { buildProposalContext } from '@/shared/services/zoho-sign/documents/proposal-context'
+import { ENVELOPE_DOCUMENTS } from '@/shared/services/zoho-sign/documents/registry'
 import { agentProcedure, baseProcedure, createTRPCRouter } from '../../init'
 
 export const contractsRouter = createTRPCRouter({
@@ -86,6 +91,115 @@ export const contractsRouter = createTRPCRouter({
       const isOmni = ctx.ability.can('manage', 'all')
       const ownerKey = isOmni ? null : ctx.session.user.id
       return contractService.resendSigningRequest(input.proposalId, ownerKey)
+    }),
+
+  /**
+   * Returns the live evaluation of which envelope documents are
+   * required/optional for a proposal. Drives the agent draft-config
+   * form. `ageOverride` lets the form preview rule changes against the
+   * age the agent is currently typing — before the value is persisted
+   * via `configureDraftEnvelope`. When omitted, the customer's saved
+   * age is used (or `null`, which yields `isSenior=false`).
+   */
+  evaluateEnvelopeDocs: agentProcedure
+    .input(z.object({
+      proposalId: z.string(),
+      ageOverride: z.number().int().min(18).max(120).optional(),
+    }))
+    .query(async ({ input }) => {
+      const proposal = await getProposal(input.proposalId)
+      if (!proposal) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Proposal not found' })
+      }
+
+      const ctx = buildProposalContext(proposal, { ageOverride: input.ageOverride })
+      const { required, optional } = evaluateDocuments(ctx)
+
+      // Render in registry order, exclude forbidden, attach labels.
+      const requiredSet = new Set(required)
+      const optionalSet = new Set(optional)
+      const docs = ENVELOPE_DOCUMENTS
+        .filter(d => requiredSet.has(d.id) || optionalSet.has(d.id))
+        .map(d => ({
+          id: d.id,
+          label: d.label,
+          status: requiredSet.has(d.id) ? ('required' as const) : ('optional' as const),
+        }))
+
+      return {
+        scenario: ctx.scenario,
+        isSenior: ctx.isSenior,
+        isLongSow: ctx.isLongSow,
+        docs,
+      }
+    }),
+
+  /**
+   * Atomically persists the agent's draft configuration:
+   *
+   *   1. customer's age (drives senior-vs-non-senior agreement variant)
+   *   2. proposal's `formMetaJSON.envelopeDocumentIds` selection
+   *
+   * Selection is re-validated server-side against the rules — never
+   * trust the client's filter. After this mutation succeeds, the
+   * existing send-proposal flow + QStash sync-contract-draft job picks
+   * up the registry path and assembles the multi-template envelope.
+   */
+  configureDraftEnvelope: agentProcedure
+    .input(z.object({
+      proposalId: z.string(),
+      age: z.number().int().min(18).max(120),
+      envelopeDocumentIds: z.array(z.enum(envelopeDocumentIds)),
+    }))
+    .mutation(async ({ input }) => {
+      const proposal = await getProposal(input.proposalId)
+      if (!proposal) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Proposal not found' })
+      }
+      if (!proposal.customer) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'No customer linked to this proposal' })
+      }
+
+      // Validate selection against the rules using the NEW age — this is
+      // the same evaluator that drives the UI, so any UX-state mismatch
+      // (e.g. agent edited URL) trips here before we persist anything.
+      const ctxForValidation = buildProposalContext(proposal, { ageOverride: input.age })
+      try {
+        validateEnvelopeSelection(ctxForValidation, input.envelopeDocumentIds)
+      }
+      catch (err) {
+        if (err instanceof EnvelopeSelectionError) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: err.message })
+        }
+        throw err
+      }
+
+      // Read existing JSONB blobs to merge (avoid clobbering sibling fields)
+      const customerId = proposal.customer.id
+      const [existingCustomer] = await db
+        .select({ customerProfileJSON: customers.customerProfileJSON })
+        .from(customers)
+        .where(eq(customers.id, customerId))
+      const updatedProfile = { ...existingCustomer?.customerProfileJSON, age: input.age }
+      const updatedFormMeta = {
+        ...proposal.formMetaJSON,
+        envelopeDocumentIds: input.envelopeDocumentIds,
+      }
+
+      // Single transaction so the proposal's selection never points to
+      // an age that hasn't been written yet (or vice versa).
+      await db.transaction(async (tx) => {
+        await tx
+          .update(customers)
+          .set({ customerProfileJSON: updatedProfile })
+          .where(eq(customers.id, customerId))
+        await tx
+          .update(proposals)
+          .set({ formMetaJSON: updatedFormMeta })
+          .where(eq(proposals.id, input.proposalId))
+      })
+
+      return { success: true, age: input.age, envelopeDocumentIds: input.envelopeDocumentIds }
     }),
 
   submitCustomerAge: baseProcedure


### PR DESCRIPTION
## Summary

Activates the registry-driven envelope assembler for real users. Extends the customer-age gate with a document-selection step: required docs render as static check rows, optional docs as shadcn Switches. Single Confirm & Continue saves both age and document selection in one transaction.

## Changes

**Server**
- `evaluateEnvelopeDocs` query (`agentProcedure`) — returns the live evaluation against an optional `ageOverride`, so the form can preview rule changes (senior/non-senior) before the value is persisted.
- `configureDraftEnvelope` mutation (`agentProcedure`) — re-validates selection server-side via `validateEnvelopeSelection`, then atomically writes `customers.customerProfileJSON.age` + `proposals.formMetaJSON.envelopeDocumentIds` in a single Drizzle transaction.
- `buildProposalContext` gains an optional `{ ageOverride }` parameter — feeds `isSenior` only, so field sources (`ho-age`) still resolve from the saved customer record.

**Client**
- New `AgentDraftConfigurationForm` replaces `CustomerAgeForm` in `AgentContractView`. Two-stage layout (age → docs), single submit. Optional selection state is stored as a raw Set and intersected against the live evaluation on every render — stale ids never leak through to either the rendered switches or the submitted payload (handles the "agent edits age, senior branch flips" case).
- `AgentContractView` gate now requires `customerAge != null && envelopeDocumentIds != null` before progressing past the form.
- Homeowner view continues using `CustomerAgeForm` unchanged (token-auth path, no doc selection).
- `proposal-flow` plumbs `proposal.formMetaJSON?.envelopeDocumentIds` through `ContractStatusPanelProps`.

## Self-Review

- `pnpm tsc --noEmit` — clean
- `pnpm lint` — clean (no new warnings/errors in changed files)
- `pnpm tsx scripts/verify-evaluate-documents.ts` — all 11 fixtures + guards pass

## Test Plan

- [ ] Visit a proposal with no `customerAge` and no `envelopeDocumentIds`. Verify the configuration form renders, accepts a non-senior age, shows the non-senior required + optional list, and persists on submit. Confirm the proposal's `formMetaJSON.envelopeDocumentIds` and customer's `customerProfileJSON.age` are both written.
- [ ] Repeat with a senior age (≥65). Verify `senior-ack` and `main-hi-senior` appear in the required rows; `main-hi-base` does not.
- [ ] Edit the age input from senior → non-senior while the form is open. Verify the doc list re-evaluates and any stale optional selections are dropped from the rendered switches.
- [ ] Toggle `material-order` ON, submit, and verify the registry path (in `contract.service.ts`) runs `assembleEnvelope` instead of the legacy fallback when the proposal email is sent.
- [ ] Existing proposals with age set but no `envelopeDocumentIds`: agent should hit the configuration form pre-filled with the saved age and only need to confirm document selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)