### PR TITLE
feat(zoho-sign): wire AWD original-contract-date from project (Phase 4.5)

### DIFF
--- a/docs/zoho-sign/template-inventory.md
+++ b/docs/zoho-sign/template-inventory.md
@@ -96,7 +96,7 @@ API capabilities + recipient unification: see [research-notes.md](./research-not
   | sent-date | CustomDate | `MM/dd/yyyy` | today |
   | start-date | CustomDate | `MMM dd yyyy` | today + 3 days |
   | completion-date | CustomDate | `MMM dd yyyy` | start-date + `validThroughTimeframe` |
-  | original-contract-date | CustomDate | `MMM dd yyyy` | **TODO (Phase 4.5)** — currently a placeholder of today; agent must edit on the draft before sending. Real source is the project's first-contract `contractSentAt`. |
+  | original-contract-date | CustomDate | `MMM dd yyyy` | Project's earliest `contractSentAt` across all proposals on all meetings of this project (joined in `getProposal` as `projectFirstContractSentAt`, surfaced as `ctx.originalContractDate`). Falls back to today defensively when missing. |
 
 > **Date format quirk:** AWD's `sent-date` accepts `MM/dd/yyyy` while its other CustomDate fields require `MMM dd yyyy`. Sending the wrong format returns HTTP 400 with `code 8033 — Date format is invalid`. The registry uses two distinct field sources (`sentDateSrc` vs `formatZohoShortDate`-based) to handle this.
 

--- a/scripts/verify-assemble-envelope.ts
+++ b/scripts/verify-assemble-envelope.ts
@@ -64,6 +64,9 @@ function makeFakeContext(recipientEmail: string): ProposalContext {
     isLongSow: false,
     finalTcp: 7500,
     sowText: 'Phase 4 smoke-test additional work.',
+    // Synthetic original-contract-date 60 days ago — exercises the
+    // Phase 4.5 wiring without needing a real project lookup.
+    originalContractDate: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
   }
 }
 

--- a/scripts/verify-evaluate-documents.ts
+++ b/scripts/verify-evaluate-documents.ts
@@ -34,6 +34,7 @@ function makeContext({ scenario, isSenior, isLongSow }: FixtureInput): ProposalC
     isLongSow,
     finalTcp: 50000,
     sowText: '',
+    originalContractDate: null,
   }
 }
 

--- a/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
@@ -183,9 +183,9 @@ export function AgentContractView({
             <>
               {/* Signer status grid */}
               <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-                {contractStatus.signerStatuses.map((signer, i) => (
+                {contractStatus.signerStatuses.map(signer => (
                   <div
-                    key={`${signer.role}-${signer.recipientEmail || i}`}
+                    key={signer.role}
                     className={cn(
                       'flex items-center gap-3 rounded-lg border p-3',
                       signer.status === 'SIGNED'

--- a/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
@@ -157,9 +157,6 @@ export function AgentContractView({
             )}
           </div>
 
-          {/* Draft-config gate — both age AND envelope document selection
-              must be set before any contract actions. The form persists
-              both atomically via configureDraftEnvelope. */}
           {!contractStatus && (customerAge == null || envelopeDocumentIds == null) && (
             <AgentDraftConfigurationForm
               proposalId={proposalId}
@@ -167,12 +164,10 @@ export function AgentContractView({
             />
           )}
 
-          {/* State: Draft is being created by background job */}
           {!contractStatus && isDraftSyncing && customerAge != null && envelopeDocumentIds != null && (
             <DraftSyncingState />
           )}
 
-          {/* State: No contract yet (age + docs must be set) */}
           {!contractStatus && !isDraftSyncing && customerAge != null && envelopeDocumentIds != null && (
             <NoContractState
               isSent={isSent}

--- a/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-contract-view.tsx
@@ -183,9 +183,9 @@ export function AgentContractView({
             <>
               {/* Signer status grid */}
               <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2">
-                {contractStatus.signerStatuses.map(signer => (
+                {contractStatus.signerStatuses.map((signer, i) => (
                   <div
-                    key={signer.role}
+                    key={`${signer.role}-${signer.recipientEmail || i}`}
                     className={cn(
                       'flex items-center gap-3 rounded-lg border p-3',
                       signer.status === 'SIGNED'

--- a/src/shared/components/contract-status-panel/ui/agent-draft-configuration-form.tsx
+++ b/src/shared/components/contract-status-panel/ui/agent-draft-configuration-form.tsx
@@ -4,52 +4,46 @@ import type { EnvelopeDocumentId } from '@/shared/constants/enums'
 import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query'
 import { Check, Loader2, ShieldCheck } from 'lucide-react'
 import { motion } from 'motion/react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/shared/components/ui/button'
 import { Input } from '@/shared/components/ui/input'
 import { Switch } from '@/shared/components/ui/switch'
 import { useInvalidation } from '@/shared/dal/client/use-invalidation'
-import { cn } from '@/shared/lib/utils'
+import { useDebounce } from '@/shared/hooks/use-debounce'
 import { useTRPC } from '@/trpc/helpers'
 
 interface AgentDraftConfigurationFormProps {
   proposalId: string
-  /** Customer's currently saved age. Pre-fills the input if present. */
   initialAge: number | null
 }
 
 /**
- * Pre-send draft configuration for the agent. Two stages, single submit:
- *
- *   1. Customer age — drives senior-vs-non-senior agreement variant
- *      and reveals the document selector once valid.
- *   2. Document selector — required docs render as static check rows
- *      (cannot be unchecked), optional docs render as Switches that
- *      default off. List comes from the registry-driven evaluator.
- *
- * Submitting fires `configureDraftEnvelope`, which atomically persists
- * both the age and the selection. The send-proposal flow then picks up
- * the registry path and assembles the envelope from the chosen docs.
+ * Pre-send draft configuration: customer age + envelope document
+ * selection persisted atomically via configureDraftEnvelope. Required
+ * docs render as static rows; optional docs as Switches. Once submitted,
+ * the send-proposal flow picks the registry path and assembles the
+ * multi-template envelope.
  */
 export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDraftConfigurationFormProps) {
   const trpc = useTRPC()
   const { invalidateProposal } = useInvalidation()
 
   const [ageInput, setAgeInput] = useState(initialAge != null ? String(initialAge) : '')
-  // Raw selection — may contain ids that are no longer applicable when
-  // senior status flips. The derived `validSelected` below intersects
-  // against the current evaluation, so stale entries never leak into
-  // either the rendered switches or the submitted payload.
   const [optionalSelected, setOptionalSelected] = useState<Set<EnvelopeDocumentId>>(() => new Set())
 
   const parsedAge = Number.parseInt(ageInput, 10)
   const isAgeValid = !Number.isNaN(parsedAge) && parsedAge >= 18 && parsedAge <= 120
 
+  // Debounce so each keystroke doesn't fire a server roundtrip through
+  // getProposal's joins + subquery — only the senior-status flip at 65
+  // changes the doc list.
+  const debouncedAge = useDebounce(isAgeValid ? parsedAge : undefined, 250)
+
   const evaluation = useQuery(
     trpc.proposalsRouter.contracts.evaluateEnvelopeDocs.queryOptions(
-      { proposalId, ageOverride: isAgeValid ? parsedAge : undefined },
-      { enabled: isAgeValid, placeholderData: keepPreviousData },
+      { proposalId, ageOverride: debouncedAge },
+      { enabled: debouncedAge != null, placeholderData: keepPreviousData },
     ),
   )
 
@@ -65,39 +59,11 @@ export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDra
     }),
   )
 
-  const requiredDocs = useMemo(
-    () => evaluation.data?.docs.filter(d => d.status === 'required') ?? [],
-    [evaluation.data],
-  )
-  const optionalDocs = useMemo(
-    () => evaluation.data?.docs.filter(d => d.status === 'optional') ?? [],
-    [evaluation.data],
-  )
-
-  // Derived effective selection — drops any ids that are no longer
-  // optional under the current evaluation (e.g. agent edited age, the
-  // senior branch flipped, a doc switched between optional/forbidden).
-  const validSelected = useMemo<Set<EnvelopeDocumentId>>(() => {
-    const allowed = new Set(optionalDocs.map(d => d.id))
-    const next = new Set<EnvelopeDocumentId>()
-    for (const id of optionalSelected) {
-      if (allowed.has(id)) {
-        next.add(id)
-      }
-    }
-    return next
-  }, [optionalSelected, optionalDocs])
-
-  function handleSubmit() {
-    if (!isAgeValid || !evaluation.data) {
-      return
-    }
-    const selection = [
-      ...requiredDocs.map(d => d.id),
-      ...optionalDocs.filter(d => validSelected.has(d.id)).map(d => d.id),
-    ]
-    submit.mutate({ proposalId, age: parsedAge, envelopeDocumentIds: selection })
-  }
+  const docs = evaluation.data?.docs ?? []
+  const requiredDocs = docs.filter(d => d.status === 'required')
+  const optionalDocs = docs.filter(d => d.status === 'optional')
+  const showDocs = isAgeValid && evaluation.data != null
+  const isPending = submit.isPending
 
   function toggleOptional(id: EnvelopeDocumentId, checked: boolean) {
     setOptionalSelected((prev) => {
@@ -112,8 +78,19 @@ export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDra
     })
   }
 
-  const showDocs = isAgeValid && evaluation.data != null
-  const isPending = submit.isPending
+  function handleSubmit() {
+    if (!isAgeValid || !evaluation.data) {
+      return
+    }
+    // Filter optionalSelected against current optionalDocs — drops any
+    // ids that became forbidden when senior status flipped.
+    const allowedOptional = new Set(optionalDocs.map(d => d.id))
+    const selection: EnvelopeDocumentId[] = [
+      ...requiredDocs.map(d => d.id),
+      ...[...optionalSelected].filter(id => allowedOptional.has(id)),
+    ]
+    submit.mutate({ proposalId, age: parsedAge, envelopeDocumentIds: selection })
+  }
 
   return (
     <motion.div
@@ -166,17 +143,31 @@ export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDra
             <p className="text-xs font-medium text-muted-foreground">Documents in this envelope</p>
             <div className="mt-2 flex flex-col gap-1.5">
               {requiredDocs.map(doc => (
-                <RequiredRow key={doc.id} label={doc.label} />
+                <div
+                  key={doc.id}
+                  className="flex items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Check className="size-4 text-primary" />
+                    <span className="text-sm">{doc.label}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">Required</span>
+                </div>
               ))}
               {optionalDocs.map(doc => (
-                <OptionalRow
+                <label
                   key={doc.id}
-                  id={doc.id}
-                  label={doc.label}
-                  checked={validSelected.has(doc.id)}
-                  disabled={isPending}
-                  onChange={checked => toggleOptional(doc.id, checked)}
-                />
+                  htmlFor={`opt-${doc.id}`}
+                  className="flex cursor-pointer items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2 hover:border-border"
+                >
+                  <span className="text-sm">{doc.label}</span>
+                  <Switch
+                    id={`opt-${doc.id}`}
+                    checked={optionalSelected.has(doc.id)}
+                    disabled={isPending}
+                    onCheckedChange={checked => toggleOptional(doc.id, checked)}
+                  />
+                </label>
               ))}
             </div>
           </div>
@@ -199,49 +190,5 @@ export function AgentDraftConfigurationForm({ proposalId, initialAge }: AgentDra
           : 'Confirm & Continue'}
       </Button>
     </motion.div>
-  )
-}
-
-function RequiredRow({ label }: { label: string }) {
-  return (
-    <div className={cn(
-      'flex items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2',
-    )}
-    >
-      <div className="flex items-center gap-2">
-        <Check className="size-4 text-primary" />
-        <span className="text-sm">{label}</span>
-      </div>
-      <span className="text-xs text-muted-foreground">Required</span>
-    </div>
-  )
-}
-
-function OptionalRow({
-  id,
-  label,
-  checked,
-  disabled,
-  onChange,
-}: {
-  id: EnvelopeDocumentId
-  label: string
-  checked: boolean
-  disabled: boolean
-  onChange: (checked: boolean) => void
-}) {
-  return (
-    <label
-      htmlFor={`opt-${id}`}
-      className="flex cursor-pointer items-center justify-between rounded-md border border-border/60 bg-background/40 px-3 py-2 hover:border-border"
-    >
-      <span className="text-sm">{label}</span>
-      <Switch
-        id={`opt-${id}`}
-        checked={checked}
-        disabled={disabled}
-        onCheckedChange={onChange}
-      />
-    </label>
   )
 }

--- a/src/shared/dal/server/proposals/api.ts
+++ b/src/shared/dal/server/proposals/api.ts
@@ -1,6 +1,6 @@
 import type { InsertProposalSchema } from '@/shared/db/schema/proposals'
 import { randomBytes } from 'node:crypto'
-import { and, count, desc, eq, getTableColumns, max } from 'drizzle-orm'
+import { and, count, desc, eq, getTableColumns, max, sql } from 'drizzle-orm'
 import { db } from '@/shared/db'
 import { customers } from '@/shared/db/schema/customers'
 import { meetings } from '@/shared/db/schema/meetings'
@@ -65,6 +65,19 @@ export async function getProposal(proposalId: string) {
       // project. Drives envelope-scenario derivation in
       // src/shared/services/zoho-sign/documents/proposal-context.ts.
       meetingProjectId: meetings.projectId,
+      // Earliest contract_sent_at across all proposals on all meetings
+      // tied to this proposal's project. Drives AWD's
+      // `original-contract-date` field on upsell envelopes (the date
+      // the project's initial agreement was sent). Null when meeting
+      // has no project (initial scenario) — the field is not used in
+      // initial envelopes anyway.
+      projectFirstContractSentAt: sql<string | null>`(
+        SELECT MIN(p2.contract_sent_at)
+        FROM ${proposals} p2
+        JOIN ${meetings} m2 ON m2.id = p2.meeting_id
+        WHERE m2.project_id = ${meetings.projectId}
+          AND p2.contract_sent_at IS NOT NULL
+      )`,
     })
     .from(proposals)
     .leftJoin(meetings, eq(meetings.id, proposals.meetingId))

--- a/src/shared/services/contract.service.ts
+++ b/src/shared/services/contract.service.ts
@@ -320,7 +320,6 @@ function createContractService() {
           actions: {
             role: string
             action_status: string
-            recipient_email: string
           }[]
         }
       }

--- a/src/shared/services/contract.service.ts
+++ b/src/shared/services/contract.service.ts
@@ -1,5 +1,5 @@
 import type { Buffer } from 'node:buffer'
-import type { ZohoActionStatus, ZohoContractStatus, ZohoRequestStatus } from '@/shared/services/zoho-sign/types'
+import type { ZohoContractStatus, ZohoRequestStatus } from '@/shared/services/zoho-sign/types'
 import { getProposal, updateProposal } from '@/shared/dal/server/proposals/api'
 import { pdfService } from '@/shared/services/pdf.service'
 import { countPdfPages } from '@/shared/services/pdf/count-pdf-pages'
@@ -7,6 +7,7 @@ import { ZOHO_SIGN_BASE_URL } from '@/shared/services/zoho-sign/constants'
 import { assembleEnvelope } from '@/shared/services/zoho-sign/documents/assemble-envelope'
 import { buildProposalContext } from '@/shared/services/zoho-sign/documents/proposal-context'
 import { buildSigningRequest } from '@/shared/services/zoho-sign/lib/build-signing-request'
+import { dedupeSignerStatuses } from '@/shared/services/zoho-sign/lib/dedupe-signer-statuses'
 import { getZohoAccessToken } from '@/shared/services/zoho-sign/lib/get-access-token'
 
 interface ZohoCreateDocResponse {
@@ -14,35 +15,6 @@ interface ZohoCreateDocResponse {
     request_id: string
     request_status: string
   }
-}
-
-/**
- * Zoho returns one `actions` entry per (template × signer-role × recipient).
- * For a multi-template envelope where the homeowner signs N templates,
- * that's N entries with role=Homeowner and the same email — which both
- * collides on the React `key` in the UI grid AND looks wrong (one row per
- * template). Collapse by `(role, recipientEmail)` and pick the lowest
- * status across the group: the signer hasn't truly progressed past the
- * least-advanced template, so we surface that.
- */
-const ACTION_STATUS_RANK: Record<ZohoActionStatus, number> = {
-  NOACTION: 0,
-  UNOPENED: 1,
-  VIEWED: 2,
-  SIGNED: 3,
-}
-
-function dedupeSignerStatuses(actions: { role: string, action_status: string, recipient_email: string }[]) {
-  const grouped = new Map<string, { role: string, status: ZohoActionStatus, recipientEmail: string }>()
-  for (const a of actions) {
-    const key = `${a.role}::${a.recipient_email}`
-    const status = a.action_status as ZohoActionStatus
-    const existing = grouped.get(key)
-    if (!existing || ACTION_STATUS_RANK[status] < ACTION_STATUS_RANK[existing.status]) {
-      grouped.set(key, { role: a.role, status, recipientEmail: a.recipient_email })
-    }
-  }
-  return Array.from(grouped.values())
 }
 
 function createContractService() {

--- a/src/shared/services/zoho-sign/documents/proposal-context.ts
+++ b/src/shared/services/zoho-sign/documents/proposal-context.ts
@@ -30,6 +30,9 @@ export function buildProposalContext(
   const scenario: EnvelopeScenario = proposal.meetingProjectId !== null ? 'upsell' : 'initial'
   const sowText = sowToPlaintext(proposal.projectJSON.data.sow ?? [])
   const ageForSeniorCheck = options.ageOverride ?? proposal.customer?.customerAge
+  const originalContractDate = proposal.projectFirstContractSentAt
+    ? new Date(proposal.projectFirstContractSentAt)
+    : null
   return {
     proposal,
     scenario,
@@ -37,5 +40,6 @@ export function buildProposalContext(
     isLongSow: isLongSow(sowText),
     finalTcp: computeFinalTcp(proposal.fundingJSON.data),
     sowText,
+    originalContractDate,
   }
 }

--- a/src/shared/services/zoho-sign/documents/proposal-context.ts
+++ b/src/shared/services/zoho-sign/documents/proposal-context.ts
@@ -7,21 +7,10 @@ import { sowToPlaintext } from '@/shared/lib/tiptap-to-text'
 import { isLongSow } from '../lib/is-long-sow'
 
 /**
- * Builds the snapshot all envelope-document predicates and field
- * sources resolve against. Pure: same input, same output, no I/O. Built
- * once per draft creation; passed through to evaluator + assembler.
- *
- * Scenario is derived from the proposal's meeting's projectId — null
- * means initial sale (a new project will be created if the proposal
- * is approved); non-null means upsell on an existing project. The
- * meeting-projectId join lives in the DAL's getProposal so callers
- * don't need to fetch it separately.
- *
- * `ageOverride` lets the agent UI preview rule evaluation against an
- * age the user is currently typing — before that value is persisted to
- * the customer record. The override only feeds `isSenior`; field
- * sources still resolve `ho-age` from `customer.customerAge`, so this
- * never affects the actual values that ship to Zoho.
+ * Pure snapshot for predicates + field sources. `ageOverride` only
+ * feeds `isSenior` (rules-only) — field sources still resolve `ho-age`
+ * from the saved customer record, so an override never affects values
+ * shipped to Zoho.
  */
 export function buildProposalContext(
   proposal: ProposalWithCustomer,

--- a/src/shared/services/zoho-sign/documents/registry.ts
+++ b/src/shared/services/zoho-sign/documents/registry.ts
@@ -74,13 +74,17 @@ const completionDateZohoSrc: FieldSource = (ctx) => {
 const sentDateSrc: FieldSource = () => new Date().toLocaleDateString('en-US')
 
 // AWD's original-contract-date refers to when the PROJECT'S original
-// contract was signed (not the upsell proposal's creation). The true
-// source is project-level data — the project's first proposal's
-// contractSentAt. Until project lookup lands in proposal-context.ts
-// (Phase 4.5 follow-up), we fall back to today as a placeholder so the
-// envelope creates successfully. The agent must edit this field on the
-// draft before sending.
-const originalContractDatePlaceholderSrc: FieldSource = () => formatZohoShortDate(new Date())
+// contract was sent (not the upsell proposal's creation). Sourced from
+// `ctx.originalContractDate` — the earliest contract-sent date across
+// all proposals on all meetings of this proposal's project, populated
+// by getProposal's projectFirstContractSentAt subquery and surfaced
+// through buildProposalContext. Falls back to today only if the value
+// is missing (defensive — shouldn't happen for upsells given the
+// project-creation rule).
+const originalContractDateSrc: FieldSource = (ctx) => {
+  const date = ctx.originalContractDate ?? new Date()
+  return formatZohoShortDate(date)
+}
 
 const baseHomeownerFieldMappings: Record<string, FieldSource> = {
   'ho-name': customerNameSrc,
@@ -190,7 +194,7 @@ export const ENVELOPE_DOCUMENTS: readonly EnvelopeDocument[] = [
       'sent-date': sentDateSrc,
       'start-date': startDateZohoSrc,
       'completion-date': completionDateZohoSrc,
-      'original-contract-date': originalContractDatePlaceholderSrc,
+      'original-contract-date': originalContractDateSrc,
     },
     signerActions: ZOHO_SIGN_TEMPLATES.awd.actions,
   },

--- a/src/shared/services/zoho-sign/documents/registry.ts
+++ b/src/shared/services/zoho-sign/documents/registry.ts
@@ -1,4 +1,5 @@
 import type { EnvelopeDocument, FieldSource } from './types'
+import { format } from 'date-fns'
 import { computeFinalTcp } from '@/shared/entities/proposals/lib/compute-final-tcp'
 import { pdfService } from '@/shared/services/pdf.service'
 import { ZOHO_SIGN_TEMPLATES } from '../constants'
@@ -26,64 +27,48 @@ const customerAgeSrc: FieldSource = ctx => String(ctx.proposal.customer?.custome
 const tcpSrc: FieldSource = ctx => String(ctx.finalTcp)
 const depositSrc: FieldSource = ctx => String(ctx.proposal.fundingJSON.data.depositAmount)
 
-// Zoho's CustomDate fields validate against the template's date_format.
-// AWD's start-date / completion-date / original-contract-date are
-// configured as `MMM dd yyyy` (e.g. "Apr 28 2026"). The base / senior
-// templates use plain Textfield dates so they accept any printable
-// string — those keep using toLocaleDateString. Use the *ZohoSrc
-// variants when targeting a CustomDate field.
-const ZOHO_SHORT_DATE_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const
-function formatZohoShortDate(date: Date): string {
-  const month = ZOHO_SHORT_DATE_MONTHS[date.getMonth()]
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${month} ${day} ${date.getFullYear()}`
-}
-
+// Zoho per-template date format quirk: AWD's start-date / completion-date /
+// original-contract-date are CustomDate fields with `MMM dd yyyy` validation;
+// every template's sent-date is `MM/dd/yyyy`; base/senior start/completion
+// are plain Textfield (accept any printable string). Use *ZohoSrc variants
+// when targeting AWD CustomDate fields.
 const startDateTextSrc: FieldSource = () => {
   const d = new Date()
   d.setDate(d.getDate() + 3)
-  return d.toLocaleDateString('en-US')
+  return format(d, 'M/d/yyyy')
 }
 
 const completionDateTextSrc: FieldSource = (ctx) => {
   const days = Number(ctx.proposal.projectJSON.data.validThroughTimeframe.replace(/\D/g, ''))
   const d = new Date()
   d.setDate(d.getDate() + 3 + days)
-  return d.toLocaleDateString('en-US')
+  return format(d, 'M/d/yyyy')
 }
 
 const startDateZohoSrc: FieldSource = () => {
   const d = new Date()
   d.setDate(d.getDate() + 3)
-  return formatZohoShortDate(d)
+  return format(d, 'MMM dd yyyy')
 }
 
 const completionDateZohoSrc: FieldSource = (ctx) => {
   const days = Number(ctx.proposal.projectJSON.data.validThroughTimeframe.replace(/\D/g, ''))
   const d = new Date()
   d.setDate(d.getDate() + 3 + days)
-  return formatZohoShortDate(d)
+  return format(d, 'MMM dd yyyy')
 }
 
-// Zoho per-template date format quirk: every template's `sent-date`
-// field is configured with date_format `MM/dd/yyyy` (verified via real
-// mergesend). AWD's `start-date` / `completion-date` /
-// `original-contract-date` use `MMM dd yyyy`. Other templates'
-// start/completion fields are plain Textfield and accept any printable
-// string. Keep this in sync with the inventory artifact.
-const sentDateSrc: FieldSource = () => new Date().toLocaleDateString('en-US')
+const sentDateSrc: FieldSource = () => format(new Date(), 'M/d/yyyy')
 
-// AWD's original-contract-date refers to when the PROJECT'S original
-// contract was sent (not the upsell proposal's creation). Sourced from
-// `ctx.originalContractDate` — the earliest contract-sent date across
-// all proposals on all meetings of this proposal's project, populated
-// by getProposal's projectFirstContractSentAt subquery and surfaced
-// through buildProposalContext. Falls back to today only if the value
-// is missing (defensive — shouldn't happen for upsells given the
-// project-creation rule).
+// AWD-only field — invariant: upsells run on a project that was created
+// when a prior proposal was approved, so `originalContractDate` is always
+// set. Throwing on null surfaces a real data integrity bug instead of
+// silently shipping today's date as the original contract date.
 const originalContractDateSrc: FieldSource = (ctx) => {
-  const date = ctx.originalContractDate ?? new Date()
-  return formatZohoShortDate(date)
+  if (!ctx.originalContractDate) {
+    throw new Error('originalContractDate is null — upsell envelope on a project with no contract-sent proposal')
+  }
+  return format(ctx.originalContractDate, 'MMM dd yyyy')
 }
 
 const baseHomeownerFieldMappings: Record<string, FieldSource> = {

--- a/src/shared/services/zoho-sign/documents/types.ts
+++ b/src/shared/services/zoho-sign/documents/types.ts
@@ -18,6 +18,17 @@ export interface ProposalContext {
   finalTcp: number
   /** Plaintext of the SOW (already computed once for the long/short check). */
   sowText: string
+  /**
+   * Date the project's original (initial-sale) agreement was sent —
+   * sourced from the earliest `contractSentAt` across all proposals on
+   * all meetings of this proposal's project. Used by AWD's
+   * `original-contract-date` field on upsell envelopes. Null in the
+   * initial scenario (no project yet) and as a defensive fallback if
+   * the project has no contract-sent proposal yet (shouldn't happen
+   * given the project-creation rule, but assemblers should degrade
+   * gracefully).
+   */
+  originalContractDate: Date | null
 }
 
 /** Resolves a Zoho field's value from the context. Pure function. */

--- a/src/shared/services/zoho-sign/documents/types.ts
+++ b/src/shared/services/zoho-sign/documents/types.ts
@@ -19,14 +19,9 @@ export interface ProposalContext {
   /** Plaintext of the SOW (already computed once for the long/short check). */
   sowText: string
   /**
-   * Date the project's original (initial-sale) agreement was sent —
-   * sourced from the earliest `contractSentAt` across all proposals on
-   * all meetings of this proposal's project. Used by AWD's
-   * `original-contract-date` field on upsell envelopes. Null in the
-   * initial scenario (no project yet) and as a defensive fallback if
-   * the project has no contract-sent proposal yet (shouldn't happen
-   * given the project-creation rule, but assemblers should degrade
-   * gracefully).
+   * Earliest `contractSentAt` across all proposals on all meetings of
+   * this proposal's project. Fills AWD's `original-contract-date`
+   * field on upsell envelopes. Null on initial-sale (no project yet).
    */
   originalContractDate: Date | null
 }

--- a/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
+++ b/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
@@ -9,24 +9,19 @@ interface RawAction {
 
 /**
  * Zoho returns one `actions` entry per (template × signer-role × recipient).
- * A multi-template envelope where the homeowner signs N templates yields N
- * entries with role=Homeowner and the same email — collide on the React
- * `key` prop and surface as N rows for one person. Collapse by
- * `(role, recipientEmail)` and pick the lowest-ranked status across the
- * group: signer state should reflect the least-advanced template, since
- * the envelope isn't truly signed until every template is.
+ * A multi-template envelope where the homeowner signs N templates yields
+ * N entries with role=Homeowner — surface those as one row per role with
+ * the lowest-ranked status across the group, so "Homeowner" reads as
+ * the actual party state ("did this side sign?"), not template plumbing.
+ * Co-signer support would need a richer model.
  */
 export function dedupeSignerStatuses(actions: RawAction[]): ZohoSignerStatus[] {
   const grouped = new Map<string, ZohoSignerStatus>()
   for (const a of actions) {
-    // Normalize email so case/whitespace variations from Zoho don't
-    // produce false-distinct keys for the same recipient.
-    const normalizedEmail = (a.recipient_email ?? '').trim().toLowerCase()
-    const key = `${a.role}::${normalizedEmail}`
     const status = a.action_status as ZohoActionStatus
-    const existing = grouped.get(key)
+    const existing = grouped.get(a.role)
     if (!existing || zohoActionStatuses.indexOf(status) < zohoActionStatuses.indexOf(existing.status)) {
-      grouped.set(key, { role: a.role, status, recipientEmail: a.recipient_email })
+      grouped.set(a.role, { role: a.role, status, recipientEmail: a.recipient_email })
     }
   }
   return Array.from(grouped.values())

--- a/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
+++ b/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
@@ -19,7 +19,10 @@ interface RawAction {
 export function dedupeSignerStatuses(actions: RawAction[]): ZohoSignerStatus[] {
   const grouped = new Map<string, ZohoSignerStatus>()
   for (const a of actions) {
-    const key = `${a.role}::${a.recipient_email}`
+    // Normalize email so case/whitespace variations from Zoho don't
+    // produce false-distinct keys for the same recipient.
+    const normalizedEmail = (a.recipient_email ?? '').trim().toLowerCase()
+    const key = `${a.role}::${normalizedEmail}`
     const status = a.action_status as ZohoActionStatus
     const existing = grouped.get(key)
     if (!existing || zohoActionStatuses.indexOf(status) < zohoActionStatuses.indexOf(existing.status)) {

--- a/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
+++ b/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
@@ -4,7 +4,6 @@ import { zohoActionStatuses } from '../types'
 interface RawAction {
   role: string
   action_status: string
-  recipient_email: string
 }
 
 /**
@@ -21,7 +20,7 @@ export function dedupeSignerStatuses(actions: RawAction[]): ZohoSignerStatus[] {
     const status = a.action_status as ZohoActionStatus
     const existing = grouped.get(a.role)
     if (!existing || zohoActionStatuses.indexOf(status) < zohoActionStatuses.indexOf(existing.status)) {
-      grouped.set(a.role, { role: a.role, status, recipientEmail: a.recipient_email })
+      grouped.set(a.role, { role: a.role, status })
     }
   }
   return Array.from(grouped.values())

--- a/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
+++ b/src/shared/services/zoho-sign/lib/dedupe-signer-statuses.ts
@@ -1,0 +1,30 @@
+import type { ZohoActionStatus, ZohoSignerStatus } from '../types'
+import { zohoActionStatuses } from '../types'
+
+interface RawAction {
+  role: string
+  action_status: string
+  recipient_email: string
+}
+
+/**
+ * Zoho returns one `actions` entry per (template × signer-role × recipient).
+ * A multi-template envelope where the homeowner signs N templates yields N
+ * entries with role=Homeowner and the same email — collide on the React
+ * `key` prop and surface as N rows for one person. Collapse by
+ * `(role, recipientEmail)` and pick the lowest-ranked status across the
+ * group: signer state should reflect the least-advanced template, since
+ * the envelope isn't truly signed until every template is.
+ */
+export function dedupeSignerStatuses(actions: RawAction[]): ZohoSignerStatus[] {
+  const grouped = new Map<string, ZohoSignerStatus>()
+  for (const a of actions) {
+    const key = `${a.role}::${a.recipient_email}`
+    const status = a.action_status as ZohoActionStatus
+    const existing = grouped.get(key)
+    if (!existing || zohoActionStatuses.indexOf(status) < zohoActionStatuses.indexOf(existing.status)) {
+      grouped.set(key, { role: a.role, status, recipientEmail: a.recipient_email })
+    }
+  }
+  return Array.from(grouped.values())
+}

--- a/src/shared/services/zoho-sign/types.ts
+++ b/src/shared/services/zoho-sign/types.ts
@@ -19,7 +19,6 @@ export type ZohoActionStatus = (typeof zohoActionStatuses)[number]
 export interface ZohoSignerStatus {
   role: string
   status: ZohoActionStatus
-  recipientEmail: string
 }
 
 export interface ZohoContractStatus {

--- a/src/trpc/routers/proposals.router/contracts.router.ts
+++ b/src/trpc/routers/proposals.router/contracts.router.ts
@@ -94,12 +94,8 @@ export const contractsRouter = createTRPCRouter({
     }),
 
   /**
-   * Returns the live evaluation of which envelope documents are
-   * required/optional for a proposal. Drives the agent draft-config
-   * form. `ageOverride` lets the form preview rule changes against the
-   * age the agent is currently typing — before the value is persisted
-   * via `configureDraftEnvelope`. When omitted, the customer's saved
-   * age is used (or `null`, which yields `isSenior=false`).
+   * Drives the agent draft-config form. `ageOverride` previews
+   * senior-vs-non-senior rule changes against an unsaved age.
    */
   evaluateEnvelopeDocs: agentProcedure
     .input(z.object({
@@ -114,8 +110,6 @@ export const contractsRouter = createTRPCRouter({
 
       const ctx = buildProposalContext(proposal, { ageOverride: input.ageOverride })
       const { required, optional } = evaluateDocuments(ctx)
-
-      // Render in registry order, exclude forbidden, attach labels.
       const requiredSet = new Set(required)
       const optionalSet = new Set(optional)
       const docs = ENVELOPE_DOCUMENTS
@@ -135,15 +129,9 @@ export const contractsRouter = createTRPCRouter({
     }),
 
   /**
-   * Atomically persists the agent's draft configuration:
-   *
-   *   1. customer's age (drives senior-vs-non-senior agreement variant)
-   *   2. proposal's `formMetaJSON.envelopeDocumentIds` selection
-   *
-   * Selection is re-validated server-side against the rules — never
-   * trust the client's filter. After this mutation succeeds, the
-   * existing send-proposal flow + QStash sync-contract-draft job picks
-   * up the registry path and assembles the multi-template envelope.
+   * Atomically persists customer age + proposal envelope-document
+   * selection. Selection is re-validated against the registry rules —
+   * never trust the client's filter alone.
    */
   configureDraftEnvelope: agentProcedure
     .input(z.object({
@@ -160,9 +148,6 @@ export const contractsRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'No customer linked to this proposal' })
       }
 
-      // Validate selection against the rules using the NEW age — this is
-      // the same evaluator that drives the UI, so any UX-state mismatch
-      // (e.g. agent edited URL) trips here before we persist anything.
       const ctxForValidation = buildProposalContext(proposal, { ageOverride: input.age })
       try {
         validateEnvelopeSelection(ctxForValidation, input.envelopeDocumentIds)
@@ -174,7 +159,6 @@ export const contractsRouter = createTRPCRouter({
         throw err
       }
 
-      // Read existing JSONB blobs to merge (avoid clobbering sibling fields)
       const customerId = proposal.customer.id
       const [existingCustomer] = await db
         .select({ customerProfileJSON: customers.customerProfileJSON })
@@ -186,8 +170,6 @@ export const contractsRouter = createTRPCRouter({
         envelopeDocumentIds: input.envelopeDocumentIds,
       }
 
-      // Single transaction so the proposal's selection never points to
-      // an age that hasn't been written yet (or vice versa).
       await db.transaction(async (tx) => {
         await tx
           .update(customers)


### PR DESCRIPTION
## Summary

Replaces the AWD `original-contract-date` placeholder with the real value sourced from the project's earliest `contractSentAt`. Eliminates the "agent must edit before sending" caveat for upsell envelopes.

Continues the work from #141 — multi-template dedupe, draft-config UI cleanups, dead-code removal after dedupe collapse to role-only.

## Changes

**Phase 4.5 core**
- `getProposal` adds `projectFirstContractSentAt` via a correlated `MIN(contract_sent_at)` subquery on `(proposals JOIN meetings)` filtered by the meeting's `projectId`
- `ProposalContext` gains `originalContractDate: Date | null`, populated by `buildProposalContext`
- `originalContractDateSrc` resolves from context; throws on null (upsell invariant — should never happen, surface bugs instead of silent fallback)

**Code-review cleanups (per /simplify pass)**
- Extracted `dedupeSignerStatuses` to `zoho-sign/lib/`, replaced `ACTION_STATUS_RANK` with `zohoActionStatuses.indexOf`
- Replaced hand-rolled `formatZohoShortDate` with date-fns `format`
- Inlined `RequiredRow` / `OptionalRow` (one-component-per-file convention)
- Dropped `validSelected` derived state; intersect at submit only
- Debounced age input (250ms via existing `useDebounce` hook)
- Trimmed narrative comments throughout per repo convention

**Signer dedupe finalization**
- Changed dedupe key from `(role, email)` to `role` only — UX is "did this side sign?", not "did N templates sign?"
- Dropped now-dead `recipientEmail` from `ZohoSignerStatus`, dedupe output, `RawAction` input, and the inline Zoho wire-type
- Reverted JSX key to `key={signer.role}` (deduped output is unique-by-construction)

## Self-Review

- `pnpm tsc --noEmit` clean
- `pnpm lint` clean
- `pnpm tsx scripts/verify-evaluate-documents.ts` 11/11 pass

## Test Plan

- [ ] Real upsell proposal — AWD's `original-contract-date` shows the project's first proposal's `contractSentAt`, not today
- [ ] Initial sale — agreement panel shows exactly two signer cards (Contractor + Homeowner) with aggregated status, no React key console errors
- [ ] Existing in-flight proposals (no `envelopeDocumentIds`) continue to work via the legacy fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)