### PR TITLE
refactor(email): centralize subject lines in subjects.ts factory

### DIFF
--- a/src/shared/services/email.service.ts
+++ b/src/shared/services/email.service.ts
@@ -4,6 +4,7 @@ import { resendClient } from '@/shared/services/resend/client'
 import { RESEND_FROM, RESEND_LEAD_INBOX } from '@/shared/services/resend/constants'
 import { buildSenderFrom } from '@/shared/services/resend/lib/build-sender-from'
 import { renderGeneralInquiryEmail, renderProposalEmail, renderScheduleConsultationEmail } from '@/shared/services/resend/lib/render-emails'
+import { consultationScheduledSubject, generalInquirySubject, proposalReadySubject } from '@/shared/services/resend/lib/subjects'
 
 function createEmailService() {
   return {
@@ -23,7 +24,7 @@ function createEmailService() {
         from: buildSenderFrom(params.repName),
         to: params.email,
         replyTo: params.replyTo,
-        subject: `${firstName}, your Tri Pros Remodeling proposal is ready`,
+        subject: proposalReadySubject(firstName),
         react: renderProposalEmail({
           proposalUrl,
           customerName: params.customerName,
@@ -43,7 +44,7 @@ function createEmailService() {
         to: RESEND_LEAD_INBOX,
         from: RESEND_FROM.default,
         replyTo: formData.email,
-        subject: 'Consultation scheduled!',
+        subject: consultationScheduledSubject(),
         react: renderScheduleConsultationEmail(formData),
       })
 
@@ -59,7 +60,7 @@ function createEmailService() {
         to: RESEND_LEAD_INBOX,
         from: RESEND_FROM.default,
         replyTo: formData.email,
-        subject: 'General Inquiry',
+        subject: generalInquirySubject(),
         react: renderGeneralInquiryEmail(formData),
       })
 

--- a/src/shared/services/notification.service.ts
+++ b/src/shared/services/notification.service.ts
@@ -4,6 +4,7 @@ import { user } from '@/shared/db/schema/auth'
 import { resendClient } from '@/shared/services/resend/client'
 import { RESEND_FROM } from '@/shared/services/resend/constants'
 import { renderProposalViewedEmail } from '@/shared/services/resend/lib/render-emails'
+import { proposalViewedSubject } from '@/shared/services/resend/lib/subjects'
 
 function createNotificationService() {
   return {
@@ -34,7 +35,7 @@ function createNotificationService() {
       const { error } = await resendClient.emails.send({
         from: RESEND_FROM.default,
         to: owner.email,
-        subject: `🔔 ${params.customerName} just opened their proposal`,
+        subject: proposalViewedSubject(params.customerName),
         react: renderProposalViewedEmail({
           customerName: params.customerName,
           proposalLabel: params.proposalLabel,

--- a/src/shared/services/resend/constants.ts
+++ b/src/shared/services/resend/constants.ts
@@ -1,4 +1,6 @@
 export const RESEND_BRAND_NAME = 'Tri Pros Remodeling'
+/** Shorter brand form for subject lines and other char-constrained surfaces. */
+export const RESEND_SHORT_BRAND_NAME = 'Tri Pros'
 export const RESEND_SENDER_MAILBOX = 'info@triprosremodeling.com'
 
 export const RESEND_FROM = {

--- a/src/shared/services/resend/lib/subjects.ts
+++ b/src/shared/services/resend/lib/subjects.ts
@@ -1,0 +1,30 @@
+import { RESEND_SHORT_BRAND_NAME } from '@/shared/services/resend/constants'
+
+/**
+ * Single source of truth for all Resend email subject lines.
+ *
+ * Conventions:
+ * - Customer-facing subjects lead with an emoji + first name for attention + warmth.
+ * - Internal-notification subjects lead with 🔔 so reps' inboxes can filter on it.
+ * - Keep under ~40 chars where possible — Gmail mobile truncates around 38.
+ */
+
+/** Customer-facing — sent when the rep emails the proposal. */
+export function proposalReadySubject(customerFirstName: string): string {
+  return `🏠 ${customerFirstName}, your ${RESEND_SHORT_BRAND_NAME} proposal is ready`
+}
+
+/** Internal notification — sent to the rep when a customer opens their proposal. */
+export function proposalViewedSubject(customerName: string): string {
+  return `🔔 ${customerName} just opened their proposal`
+}
+
+/** Internal notification — sent to the lead inbox when someone books via the landing page. */
+export function consultationScheduledSubject(): string {
+  return 'Consultation scheduled!'
+}
+
+/** Internal notification — sent to the lead inbox on general inquiry form submit. */
+export function generalInquirySubject(): string {
+  return 'General Inquiry'
+}


### PR DESCRIPTION
## Summary
Centralizes all Resend email subject strings into a single \`subjects.ts\` factory. Call sites import builder functions; raw subject strings no longer scattered across services.

Updates the customer-facing proposal subject to **Option 5** from the conversation:
- Before: \`<First>, your Tri Pros Remodeling proposal is ready\` (51 chars, truncates badly on mobile)
- After: \`🏠 <First>, your Tri Pros proposal is ready\` (40 chars, attention-grabbing emoji)

## Files
- **NEW** \`src/shared/services/resend/lib/subjects.ts\` — 4 named builder functions, JSDoc'd
- \`src/shared/services/resend/constants.ts\` — adds \`RESEND_SHORT_BRAND_NAME = 'Tri Pros'\`
- \`src/shared/services/email.service.ts\` — call sites use \`proposalReadySubject\`, \`consultationScheduledSubject\`, \`generalInquirySubject\`
- \`src/shared/services/notification.service.ts\` — uses \`proposalViewedSubject\`

## Behavior changes
| Subject | Before | After |
|---|---|---|
| Proposal email (customer) | \`Sean, your Tri Pros Remodeling proposal is ready\` | \`🏠 Sean, your Tri Pros proposal is ready\` |
| Consultation scheduled (internal) | \`Consultation scheduled!\` | unchanged |
| General inquiry (internal) | \`General Inquiry\` | unchanged |
| Proposal viewed (internal notify) | \`🔔 Sean Yehuda just opened their proposal\` | unchanged |

## Self-Review
- [x] \`pnpm tsc\` clean
- [x] \`pnpm lint\` — no new warnings
- [x] All 4 subject sites refactored to use the builder
- [x] No raw subject strings remain in service files

## Test Plan
- [ ] Send a real proposal post-merge — verify Gmail shows \`🏠 Sean, your Tri Pros proposal is ready\` in inbox row
- [ ] Spot-check on iOS Mail (37-42 char window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)