### PR TITLE
Improve mobile dev testing DX (stable tunnel workflow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-pnpm dev          # Start dev server (binds to 0.0.0.0:3000)
+pnpm dev          # Start dev server (port from PORT env, defaults to 3000)
+pnpm dev:mobile   # Start dev + ngrok tunnel + QR code (one command)
+pnpm tunnel       # Run only the ngrok tunnel (uses ${PORT:-3000})
 pnpm build        # Build for production
 pnpm lint         # ESLint
 # Database (PostgreSQL via Drizzle)
@@ -15,6 +17,29 @@ pnpm db:seed      # Seed Postgres database
 ```
 
 Package manager: **pnpm**. Path alias: `@/` → `src/`.
+
+## Mobile testing
+
+`pnpm dev:mobile` runs `next dev` + `ngrok` + a QR-code printer concurrently. Scan the QR with your phone camera to load the app over the static ngrok tunnel (`https://destined-emu-bold.ngrok-free.app`). Auth, cookies, and OAuth all work over the tunnel — better-auth derives the per-request base URL from `APP_HOSTS` in `src/shared/config/roots.ts` and uses the matching Google OAuth callback automatically.
+
+**Per-worktree port (parallel dev):** Each worktree picks its own port via `.env.local` (git-ignored, loaded by Next.js after `.env`):
+
+```
+# .env.local in worktree foo
+PORT=3001
+```
+
+Both `pnpm dev` and `pnpm tunnel` honor `PORT`. Multiple worktrees can run dev simultaneously on different ports.
+
+**One tunnel at a time:** The free ngrok plan allows one active tunnel. Whichever worktree runs `pnpm dev:mobile` first holds it; others get a clear ngrok error. Kill the holder, run again in the new worktree.
+
+**Adding a new host (worktree port, subdomain, etc.):**
+1. Add it to `APP_HOSTS` in `src/shared/config/roots.ts` (the single source of truth).
+2. If it needs Google sign-in, register `<host>/api/auth/callback/google` in the Google Cloud OAuth Client.
+
+**DevTools mobile viewport:** Chrome — open DevTools, then `Cmd-Shift-M` (macOS) / `Ctrl-Shift-M` (Win/Linux). Safari — Develop menu → Enter Responsive Design Mode.
+
+**When ngrok isn't enough:** Vercel Preview Deploys give a real HTTPS URL on every PR — use those for testing flows that need real domains (e.g., third-party webhook signatures bound to a public URL).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Both `pnpm dev` and `pnpm tunnel` honor `PORT`. Multiple worktrees can run dev s
 
 **One tunnel at a time:** The free ngrok plan allows one active tunnel. Whichever worktree runs `pnpm dev:mobile` first holds it; others get a clear ngrok error. Kill the holder, run again in the new worktree.
 
+**Third-party webhooks (Google Calendar push, QStash callbacks, etc.):** These resolve their public URL via `env.NGROK_URL ?? env.NEXT_PUBLIC_BASE_URL`. Whichever worktree holds the tunnel receives the webhooks — even if a different worktree created the subscription. If you're testing webhook flows, hold the tunnel in the worktree you want to receive callbacks.
+
 **Adding a new host (worktree port, subdomain, etc.):**
 1. Add it to `APP_HOSTS` in `src/shared/config/roots.ts` (the single source of truth).
 2. If it needs Google sign-in, register `<host>/api/auth/callback/google` in the Google Cloud OAuth Client.

--- a/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
+++ b/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
@@ -1,0 +1,236 @@
+# Mobile Dev Testing DX — Stable Tunnel Workflow
+
+**Issue:** [#98](https://github.com/OlisDevSpot/tri-pros-website/issues/98)
+**Date:** 2026-04-29
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+Mobile dev testing today is brittle. The static ngrok tunnel exists (`pnpm tunnel` → `https://destined-emu-bold.ngrok-free.app`), but:
+
+1. **Auth is broken through the tunnel.** Better-auth hardcodes `baseURL` and the Google OAuth `redirectURI` to `NEXT_PUBLIC_BASE_URL` (`http://localhost:3000` in dev). When the phone hits the tunnel and clicks "Sign in with Google", Google bounces the user back to localhost — unreachable from the phone, and any cookie lands on the wrong domain.
+2. **`NGROK_URL` is not in `trustedOrigins`,** so even if the redirect were correct, CSRF/origin checks would still reject the tunnel.
+3. **No one-command workflow** to start dev + tunnel with a discoverable URL on the phone.
+4. **No documentation** — the `tunnel` script is undocumented.
+
+## Goals
+
+- Auth works from both localhost (any dev port) and the tunnel **simultaneously**, with no env flipping or restart.
+- One command starts dev + tunnel + prints a QR code that points to the tunnel URL.
+- Multiple git worktrees can each run their own `pnpm dev` on a distinct port (3000–3002), and any of them can grab the tunnel on demand.
+- Workflow is documented in `CLAUDE.md` so it's discoverable by future agents and devs.
+- No regressions to production auth or local-only dev (devs who don't use mobile testing should be unaffected).
+
+## Non-goals
+
+- Replacing ngrok with a different tunnel provider.
+- Multiple simultaneous tunnels (free ngrok plan allows only one; upgrading is out of scope).
+- Per-PR Vercel preview tooling beyond a documentation pointer.
+- Automatic ngrok session recovery (listed as a "nice-to-have" in the issue; defer).
+
+## Constraints
+
+- **Free ngrok plan**, single static domain (`destined-emu-bold.ngrok-free.app`), one active tunnel at a time. Switching the tunnel between worktrees is a manual "kill the old one, start the new one" operation.
+- **`.env` is symlinked across all worktrees**, so per-worktree config (e.g., port) cannot live there. We use Next.js's standard `.env.local` for per-worktree overrides.
+
+## Design
+
+### Part 1 — `roots.ts` refactor (the foundation)
+
+`src/shared/config/roots.ts` currently does two jobs: path generation (used correctly across the app, ~95% of calls) and "absolute URL" generation (broken in three places). We sharpen the API into two clear modes and centralize the host registry.
+
+#### Audit findings
+
+`devBaseUrl` and `prodBaseUrl` are **never consumed externally** — only by `generateUrl` internally. We can refactor freely.
+
+The current `absolute: true` semantics mask three real bugs:
+
+1. **`logout-button.tsx:18`** — `router.push(${ROOTS.generateUrl('/', { absolute: true })})`. Pushes `http://localhost:3000/` in dev, breaking from a phone over the tunnel. Should be `router.push('/')`.
+2. **`account-button.tsx:17`** — same antipattern, plus a literal `}` typo: `${ROOTS.generateUrl('/', { absolute })}/profile}`.
+3. **`proposal-email.tsx:123`** — `const base = ROOTS.generateUrl('', { absolute: true })` at module scope. Without `isProduction: true`, dev-rendered emails embed `http://localhost:3000` for the hero/logo image fallbacks. Sister file `email.service.ts:19` correctly uses `isProduction: true` — they disagree.
+
+The pattern: `absolute: true` without `isProduction: true` has no legitimate caller. Every legitimate consumer (emails, GCal events, sitemap, image fallbacks) wants the **canonical production URL** because the URL outlives the request.
+
+#### New `roots.ts` shape
+
+```ts
+// src/shared/config/roots.ts
+
+// Single source of truth for "where does this app live"
+export const APP_HOSTS = {
+  prod:   ['triprosremodeling.com', 'www.triprosremodeling.com'],
+  dev:    ['localhost:3000', 'localhost:3001', 'localhost:3002'],
+  tunnel: ['destined-emu-bold.ngrok-free.app'],
+} as const
+
+const PROD_BASE_URL = `https://${APP_HOSTS.prod[0]}`
+
+interface UrlOptions {
+  absolute?: boolean
+}
+
+function generateUrl(path: string, options?: UrlOptions): string {
+  return options?.absolute ? `${PROD_BASE_URL}${path}` : path
+}
+
+const APP_ROOTS = {
+  authFlow: (options?: UrlOptions) => generateUrl('/auth-flow', options),
+  landing: { /* unchanged tree, signatures use UrlOptions */ },
+  dashboard: { /* ... */ },
+  public: { /* ... */ },
+} as const
+
+export const ROOTS = { ...APP_ROOTS, generateUrl }
+```
+
+**Two clear intents:**
+
+| Intent | API | Output | Use case |
+|---|---|---|---|
+| Path | `ROOTS.dashboard.proposals.byId(id)` | `/dashboard/proposals/abc` | Links, navigation, router.push (~95% of calls) |
+| Canonical absolute URL | `ROOTS.dashboard.proposals.byId(id, { absolute: true })` | `https://triprosremodeling.com/dashboard/proposals/abc` | Emails, GCal events, sitemap, image fallbacks |
+
+**Removed:**
+- `devBaseUrl` and `prodBaseUrl` exposed on ROOTS (only used internally; now collapsed into one `PROD_BASE_URL` constant).
+- `isProduction` option — now redundant because `absolute: true` always means prod.
+
+**Out of scope:** "Current-context absolute URL" (e.g., `intake-url-card.tsx`) keeps using `window.location.origin`. That's the right tool for that job; no need to bake it into `roots.ts`.
+
+#### Caller cleanups (Part 1.5)
+
+Adopting the new API surfaces three bugs and one ergonomics win:
+
+| File | Change | Reason |
+|---|---|---|
+| `email.service.ts:19` | Drop `isProduction: true` | Now redundant — `absolute: true` means prod |
+| `proposal-viewed-email.tsx:97` | Drop `isProduction: true` | Same |
+| `map-to-gcal.ts:85` | Drop `isProduction: true` | Same |
+| `proposal-email.tsx:123` | No code change — bug **silently fixes itself** because `absolute: true` now means prod | Side effect of new semantics |
+| `logout-button.tsx:18` | `router.push('/')` | Drop bogus absolute URL; relative is correct |
+| `account-button.tsx:17` | `router.push('/profile')` | Drop bogus absolute URL + fix typo |
+| `billing-button.tsx:17` | `router.push('/')` | Drop bogus absolute URL |
+| `marketplace-button.tsx:18` | `router.push('/')` | Drop bogus absolute URL |
+
+**Out of scope (deliberate):** `sitemap.ts` and `trpc/helpers.tsx` use `process.env.NEXT_PUBLIC_BASE_URL` directly. That's a *different* concern (runtime SSR fetch URL, not canonical URL). Leave for follow-up.
+
+### Part 1b — Better-auth dynamic baseURL
+
+Better-auth supports per-request base URL derivation. Two flavors:
+
+- **≥1.5:** `baseURL: { allowedHosts: [...], fallback }` — strict allowlist validation.
+- **1.4.x (our installed version, 1.4.18):** `advanced.trustedProxyHeaders: true` + omit `baseURL`. Better-auth derives the URL from `x-forwarded-host` / `x-forwarded-proto` (proxy headers, used by ngrok and Vercel) or falls back to `request.url` (used by direct localhost requests). OAuth callbacks then derive from that base URL automatically.
+
+We use the 1.4-compatible form now. When better-auth gets upgraded to ≥1.5, we can switch to the explicit `allowedHosts` form for stricter validation.
+
+#### Changes in `src/shared/domains/auth/server.ts`
+
+```ts
+import { APP_HOSTS } from '@/shared/config/roots'
+
+// baseURL intentionally omitted — derived per-request from proxy headers
+// (ngrok/Vercel) or request.url (localhost). See advanced.trustedProxyHeaders below.
+trustedOrigins: [
+  ...APP_HOSTS.dev.map(h => `http://${h}`),
+  ...APP_HOSTS.tunnel.map(h => `https://${h}`),
+  ...APP_HOSTS.prod.map(h => `https://${h}`),
+],
+socialProviders: {
+  google: {
+    clientId: env.GOOGLE_CLIENT_ID,
+    clientSecret: env.GOOGLE_CLIENT_SECRET,
+    // redirectURI omitted — derived from per-request baseURL
+    accessType: 'offline',
+    prompt: 'select_account consent',
+    scope: [...], // preserved from current config
+  },
+},
+advanced: {
+  crossSubDomainCookies: { enabled: true },
+  trustedProxyHeaders: true,  // NEW — enables x-forwarded-host derivation
+},
+```
+
+**Removed:**
+- Hardcoded `redirectURI` on the Google provider.
+- Static `baseURL: env.NEXT_PUBLIC_BASE_URL` (was forcing localhost in dev).
+- `BETTER_AUTH_URL` and `NEXT_PUBLIC_BASE_URL` from `trustedOrigins` (subsumed by `APP_HOSTS`-derived list; `BETTER_AUTH_URL` env stays optional for future override).
+
+**Added:**
+- `advanced.trustedProxyHeaders: true` — required for per-request URL derivation through ngrok and Vercel.
+
+**Server-side `auth.api.*` calls:** All in-tree callers pass `headers` explicitly, and `auth.api.getSession` doesn't require a base URL — it reads the session cookie from headers. No regressions.
+
+**Why this works:** All three callback URLs (`localhost`, ngrok, prod) are already registered in the Google Cloud OAuth Client (confirmed by the user). Better-auth picks the right one per request.
+
+**Cookie domain consideration:** `crossSubDomainCookies` stays enabled. Each host gets its own cookie scope; this is fine because we're not trying to share sessions across environments — each environment is independent.
+
+### Part 2 — Port-aware dev + tunnel scripts
+
+#### Per-worktree port via `.env.local`
+
+Next.js automatically loads `.env.local` after `.env` and `.env.local` is git-ignored by default. Each worktree puts its own `PORT` there:
+
+```
+# .env.local (in each worktree)
+PORT=3001
+```
+
+`next dev` reads `PORT` from env natively — no flag needed. We drop the legacy `--hostname 0.0.0.0` flag from the `dev` script (it was a workaround before the ngrok tunnel existed; ngrok handles external access now).
+
+#### Updated scripts in `package.json`
+
+```json
+"dev": "next dev",
+"tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app ${PORT:-3000}",
+"dev:mobile": "concurrently -k -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\""
+```
+
+Both `dev` and `tunnel` honor `PORT` from env (Next.js reads it for dev; the shell-expanded `${PORT:-3000}` reads it for ngrok). `dev:mobile` ties them together with `concurrently` so Ctrl-C kills both child processes.
+
+**New devDependencies:**
+- `concurrently` — runs dev + tunnel in parallel with shared lifecycle.
+- `qrcode-terminal` — tiny dep, prints ASCII QR to terminal.
+
+**New file `scripts/print-tunnel-qr.mjs`:** Reads `NGROK_URL` from `.env`, waits ~3s for the tunnel to come up, prints the URL + a QR code, and exits. (It does not poll or restart — keeps the process tree simple.)
+
+**Why not detect the live ngrok URL via the local API?** Because we use a **static** ngrok domain. The URL is known ahead of time and lives in `.env` as `NGROK_URL`. No discovery needed.
+
+**Behavior when another worktree already holds the tunnel:** ngrok prints a clear error ("tunnel session already exists" or similar). The dev process keeps running locally. The user kills the other worktree's tunnel and re-runs `dev:mobile`. We do not try to be clever about reclaiming the tunnel.
+
+### Part 3 — Documentation
+
+Add a "Mobile testing" section to `CLAUDE.md` covering:
+- `pnpm dev:mobile` workflow.
+- Per-worktree `.env.local` with `PORT=3001` (or 3002, etc.) for parallel worktree dev.
+- The single-tunnel constraint (free ngrok plan): only one worktree can hold the tunnel at a time.
+- Required env: `NGROK_URL` set to the static ngrok domain (lives in shared `.env`).
+- Note that Google OAuth Client must have all redirect URIs registered (one-time setup, already done).
+- Note that `APP_HOSTS` in `src/shared/config/roots.ts` is the single source of truth for allowed hosts; adding a worktree port or subdomain means editing that file (and registering the callback URL in Google Cloud Console).
+- DevTools shortcut for toggling the device-emulator viewport (Chrome: Cmd-Shift-M after opening DevTools; Safari: Develop menu → Enter Responsive Design Mode).
+- Pointer to Vercel Preview Deploys for cases where ngrok isn't enough.
+
+`README.md` is currently brief — adding a one-paragraph "Mobile testing" pointer there is fine but optional; CLAUDE.md is the source of truth for this codebase.
+
+## Out of scope (defer)
+
+- Detecting stale ngrok session and auto-restarting.
+- Adding `*.vercel.app` to better-auth `allowedHosts` for preview deploys (Vercel previews use unique URLs per deploy and aren't currently used for auth flows; we can add this when needed).
+- Removing legacy `BETTER_AUTH_URL` env entirely (kept optional for future override).
+
+## Risks
+
+- **Header trust:** Better-auth's dynamic baseURL relies on `X-Forwarded-Host`/`Host`. Vercel sets these correctly. Local `next dev` sets `Host` directly. Ngrok forwards them. No proxy-spoofing risk in our deployment topology.
+- **Allowlist drift:** If we add a new domain (e.g., a second tunnel, a new subdomain), we must remember to add it to `APP_HOSTS` in `roots.ts` AND register the callback URL in the Google OAuth Client. Documented in `CLAUDE.md`.
+- **Existing sessions:** Switching `baseURL` from string to object form should not invalidate existing prod sessions because cookie domain logic is unchanged. Worth verifying in dev before merge.
+
+## Success criteria
+
+- ✅ `roots.ts` exports `APP_HOSTS` and a simplified `generateUrl` (path | absolute=prod). `devBaseUrl` and `isProduction` are gone.
+- ✅ Three pre-existing bugs fixed: `proposal-email.tsx` module-level `base` no longer points to localhost; the four button `router.push` calls drop bogus absolute URLs.
+- ✅ `pnpm dev:mobile` starts dev + tunnel and prints a QR pointing at the static tunnel URL.
+- ✅ Multiple worktrees can run `pnpm dev` simultaneously on different ports (3000–3002) by setting `PORT` in each worktree's `.env.local`.
+- ✅ Any worktree can grab the tunnel by running `pnpm dev:mobile`; ngrok will tunnel to that worktree's `PORT`.
+- ✅ Sign-in with Google works through the tunnel from a mobile browser.
+- ✅ Sign-in with Google still works from any localhost dev port on desktop, simultaneously with the tunnel, no restart needed.
+- ✅ Production auth (triprosremodeling.com) unaffected.
+- ✅ Workflow documented in `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
+++ b/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
@@ -168,34 +168,50 @@ advanced: {
 
 #### Per-worktree port via `.env.local`
 
-Next.js automatically loads `.env.local` after `.env` and `.env.local` is git-ignored by default. Each worktree puts its own `PORT` there:
+`.env.local` is git-ignored (`.env*` covers it) and Next.js loads it. Each worktree puts its own `PORT` there:
 
 ```
 # .env.local (in each worktree)
 PORT=3001
 ```
 
-`next dev` reads `PORT` from env natively — no flag needed. We drop the legacy `--hostname 0.0.0.0` flag from the `dev` script (it was a workaround before the ngrok tunnel existed; ngrok handles external access now).
+#### Why we wrap `next dev` and `ngrok` in node scripts
 
-#### Updated scripts in `package.json`
+Two cross-cutting issues forced node wrappers instead of inline shell:
+
+1. **Next.js doesn't honor `PORT` from `.env.local` for the dev server bind.** It reads `PORT` from `process.env` *before* dotenv loading; if `PORT` isn't already in the process env, `next dev` defaults to 3000 (and prints "Port 3000 is in use, using available port 3001 instead" if 3000 is taken). Empirically confirmed.
+2. **pnpm/concurrently don't shell-expand `${PORT:-3000}` reliably** across the way our scripts get composed (pnpm runs script lines verbatim in the cases we observed).
+
+Both fixed by reading `.env.local` ourselves in tiny node helpers and passing `--port` / port arg explicitly.
+
+#### New scripts
+
+| Path | Purpose |
+|---|---|
+| `scripts/lib/get-port.mjs` | Shared helper. Returns `Number(process.env.PORT)` if set, else parses `PORT` from `.env.local`, else 3000. |
+| `scripts/dev.mjs` | Spawns `next dev --port <PORT>`, forwards stdio + signals. |
+| `scripts/tunnel.mjs` | Spawns `ngrok http --url=<static-domain> <PORT>`, forwards stdio + signals. |
+| `scripts/print-tunnel-qr.mjs` | Reads `NGROK_URL` from `.env`, waits ~3s, prints the tunnel URL + the resolved local port + an ASCII QR code, then exits. |
+
+#### Updated `package.json` scripts
 
 ```json
-"dev": "next dev",
-"tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app ${PORT:-3000}",
-"dev:mobile": "concurrently -k -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\""
+"dev": "node scripts/dev.mjs",
+"tunnel": "node scripts/tunnel.mjs",
+"dev:mobile": "concurrently --kill-others-on-fail -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\""
 ```
 
-Both `dev` and `tunnel` honor `PORT` from env (Next.js reads it for dev; the shell-expanded `${PORT:-3000}` reads it for ngrok). `dev:mobile` ties them together with `concurrently` so Ctrl-C kills both child processes.
+`--kill-others-on-fail` (not `-k`) is critical: the QR script intentionally exits 0 after printing, and `-k` would kill dev + tunnel on any clean exit. `--kill-others-on-fail` only triggers on non-zero exit, so dev/tunnel stay alive.
+
+The legacy `--hostname 0.0.0.0` is dropped — it was a workaround before the tunnel existed; ngrok handles external access now.
 
 **New devDependencies:**
-- `concurrently` — runs dev + tunnel in parallel with shared lifecycle.
+- `concurrently` — runs dev + tunnel in parallel with shared signal lifecycle.
 - `qrcode-terminal` — tiny dep, prints ASCII QR to terminal.
 
-**New file `scripts/print-tunnel-qr.mjs`:** Reads `NGROK_URL` from `.env`, waits ~3s for the tunnel to come up, prints the URL + a QR code, and exits. (It does not poll or restart — keeps the process tree simple.)
+**Why not detect the live ngrok URL via the local API?** Because we use a **static** ngrok domain. The URL lives in `.env` as `NGROK_URL`.
 
-**Why not detect the live ngrok URL via the local API?** Because we use a **static** ngrok domain. The URL is known ahead of time and lives in `.env` as `NGROK_URL`. No discovery needed.
-
-**Behavior when another worktree already holds the tunnel:** ngrok prints a clear error ("tunnel session already exists" or similar). The dev process keeps running locally. The user kills the other worktree's tunnel and re-runs `dev:mobile`. We do not try to be clever about reclaiming the tunnel.
+**Behavior when another worktree already holds the tunnel:** ngrok exits with a "tunnel session already exists" error. With `--kill-others-on-fail`, that brings down dev too. The user kills the other worktree's tunnel and re-runs `pnpm dev:mobile`.
 
 ### Part 3 — Documentation
 

--- a/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
+++ b/docs/superpowers/specs/2026-04-29-mobile-dev-tunnel-dx-design.md
@@ -113,56 +113,55 @@ Adopting the new API surfaces three bugs and one ergonomics win:
 
 **Out of scope (deliberate):** `sitemap.ts` and `trpc/helpers.tsx` use `process.env.NEXT_PUBLIC_BASE_URL` directly. That's a *different* concern (runtime SSR fetch URL, not canonical URL). Leave for follow-up.
 
-### Part 1b — Better-auth dynamic baseURL
+### Part 1b — Better-auth dynamic baseURL (allowedHosts pattern)
 
-Better-auth supports per-request base URL derivation. Two flavors:
+Better-auth's documented pattern for multi-domain deployments is `baseURL: { allowedHosts, fallback, protocol }`. Per request, better-auth resolves the host from `x-forwarded-host` (proxy headers used by ngrok and Vercel) or `request.url` (localhost), validates it against `allowedHosts`, and constructs a request-specific base URL. OAuth callbacks, cookies, and redirects all derive from the resolved host.
 
-- **≥1.5:** `baseURL: { allowedHosts: [...], fallback }` — strict allowlist validation.
-- **1.4.x (our installed version, 1.4.18):** `advanced.trustedProxyHeaders: true` + omit `baseURL`. Better-auth derives the URL from `x-forwarded-host` / `x-forwarded-proto` (proxy headers, used by ngrok and Vercel) or falls back to `request.url` (used by direct localhost requests). OAuth callbacks then derive from that base URL automatically.
+This pattern is **only available in better-auth ≥1.5**. We were on 1.4.18, which forced a `trustedProxyHeaders` workaround that the docs explicitly discourage ("Relying on request inference is not recommended. For security and stability, always set `baseURL` explicitly."). The first end-to-end test of the workaround crashed with `baseURL is required when crossSubdomainCookies are enabled` — the 1.4 config validator demands a static `baseURL` whenever `crossSubDomainCookies` is on, regardless of how the URL is later resolved.
 
-We use the 1.4-compatible form now. When better-auth gets upgraded to ≥1.5, we can switch to the explicit `allowedHosts` form for stricter validation.
+**We upgrade better-auth to `^1.6.9`** as part of this issue and adopt the documented pattern. The 1.4→1.6 jump has no breaking changes that affect us: the only schema-level changes are in the API key plugin (we don't use it), and `auth.api.*` signatures are stable.
 
 #### Changes in `src/shared/domains/auth/server.ts`
 
 ```ts
 import { APP_HOSTS } from '@/shared/config/roots'
 
-// baseURL intentionally omitted — derived per-request from proxy headers
-// (ngrok/Vercel) or request.url (localhost). See advanced.trustedProxyHeaders below.
-trustedOrigins: [
-  ...APP_HOSTS.dev.map(h => `http://${h}`),
-  ...APP_HOSTS.tunnel.map(h => `https://${h}`),
-  ...APP_HOSTS.prod.map(h => `https://${h}`),
-],
+baseURL: {
+  allowedHosts: [...APP_HOSTS.dev, ...APP_HOSTS.tunnel, ...APP_HOSTS.prod],
+  protocol: 'auto',                      // derives from x-forwarded-proto
+  fallback: env.NEXT_PUBLIC_BASE_URL,    // for requests outside the request lifecycle
+},
 socialProviders: {
   google: {
     clientId: env.GOOGLE_CLIENT_ID,
     clientSecret: env.GOOGLE_CLIENT_SECRET,
-    // redirectURI omitted — derived from per-request baseURL
+    // redirectURI omitted — derived per-request from baseURL
     accessType: 'offline',
     prompt: 'select_account consent',
-    scope: [...], // preserved from current config
+    scope: [...],
   },
 },
 advanced: {
-  crossSubDomainCookies: { enabled: true },
-  trustedProxyHeaders: true,  // NEW — enables x-forwarded-host derivation
+  crossSubDomainCookies: { enabled: true },  // cookie domain auto-derives from request host
+  // trustedProxyHeaders not needed — allowedHosts handles it
 },
+// trustedOrigins not declared explicitly — allowedHosts auto-adds entries
+// (localhost gets both http and https), and the fallback origin is also added.
 ```
 
 **Removed:**
 - Hardcoded `redirectURI` on the Google provider.
 - Static `baseURL: env.NEXT_PUBLIC_BASE_URL` (was forcing localhost in dev).
-- `BETTER_AUTH_URL` and `NEXT_PUBLIC_BASE_URL` from `trustedOrigins` (subsumed by `APP_HOSTS`-derived list; `BETTER_AUTH_URL` env stays optional for future override).
+- Manually constructed `trustedOrigins` array — `allowedHosts` handles it per docs.
+- `advanced.trustedProxyHeaders` — replaced by the `allowedHosts` mechanism.
 
-**Added:**
-- `advanced.trustedProxyHeaders: true` — required for per-request URL derivation through ngrok and Vercel.
+**Why this works:** All three callback URLs (localhost, ngrok, prod) are registered in the Google Cloud OAuth Client. Better-auth resolves the request host against `allowedHosts`, derives the OAuth callback URL from that, and Google sees a valid registered redirect.
 
-**Server-side `auth.api.*` calls:** All in-tree callers pass `headers` explicitly, and `auth.api.getSession` doesn't require a base URL — it reads the session cookie from headers. No regressions.
+**Cookie domain consideration:** Per docs, when `crossSubDomainCookies` is enabled with dynamic baseURL, the cookie domain auto-derives from the resolved request host. No explicit `domain` override needed for our setup (Vercel canonicalizes www↔apex; localhost and tunnel are independent contexts).
 
-**Why this works:** All three callback URLs (`localhost`, ngrok, prod) are already registered in the Google Cloud OAuth Client (confirmed by the user). Better-auth picks the right one per request.
+### Part 1c — Next.js `allowedDevOrigins` for tunnel HMR
 
-**Cookie domain consideration:** `crossSubDomainCookies` stays enabled. Each host gets its own cookie scope; this is fine because we're not trying to share sessions across environments — each environment is independent.
+Next.js logs a "Cross origin request detected from `<tunnel>` to `/_next/*`" warning (and will block in a future major) when HMR/asset requests come in over a different origin than the dev server's local one. Add `allowedDevOrigins: [...APP_HOSTS.tunnel]` to `next.config.ts` so HMR works through the tunnel.
 
 ### Part 2 — Port-aware dev + tunnel scripts
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,14 @@
 import type { NextConfig } from 'next'
+import { APP_HOSTS } from './src/shared/config/roots'
 
 const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  // Allow HMR and /_next/* asset requests through the static ngrok tunnel
+  // used by `pnpm dev:mobile`. Without this, Next.js logs a cross-origin
+  // warning and (in a future major) will block the requests outright.
+  allowedDevOrigins: [...APP_HOSTS.tunnel],
   // pdfkit reads its 14 standard-font AFM files + sRGB ICC profile via
   // fs.readFileSync(__dirname + '/data/...'). Two things conspire to
   // break this on Vercel:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "packageManager": "pnpm@10.13.1",
   "scripts": {
-    "dev": "next dev --hostname 0.0.0.0",
+    "dev": "next dev",
+    "dev:mobile": "concurrently -k -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -30,7 +31,7 @@
     "rebuild:gcal:dev": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
     "meta": "tsx scripts/meta/index.ts",
     "dispatch": "bash scripts/dispatch.sh",
-    "tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app 3000"
+    "tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app ${PORT:-3000}"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.25",
@@ -157,6 +158,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/sanitize-html": "^2.16.0",
+    "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
@@ -164,6 +166,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "playwright": "^1.58.2",
+    "qrcode-terminal": "^0.12.0",
     "shadcn": "^4.0.2",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@zxcvbn-ts/language-en": "^3.0.2",
     "ably": "^2.21.0",
     "ai": "^6.0.70",
-    "better-auth": "^1.4.5",
+    "better-auth": "^1.6.9",
     "class-variance-authority": "^0.7.1",
     "client-only": "^0.0.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "packageManager": "pnpm@10.13.1",
   "scripts": {
-    "dev": "next dev",
-    "dev:mobile": "concurrently -k -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\"",
+    "dev": "node scripts/dev.mjs",
+    "dev:mobile": "concurrently --kill-others-on-fail -n next,tunnel,qr -c blue,magenta,green \"pnpm dev\" \"pnpm tunnel\" \"node scripts/print-tunnel-qr.mjs\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -31,7 +31,7 @@
     "rebuild:gcal:dev": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
     "meta": "tsx scripts/meta/index.ts",
     "dispatch": "bash scripts/dispatch.sh",
-    "tunnel": "ngrok http --url=destined-emu-bold.ngrok-free.app ${PORT:-3000}"
+    "tunnel": "node scripts/tunnel.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: ^6.0.70
         version: 6.0.70(zod@4.3.6)
       better-auth:
-        specifier: ^1.4.5
-        version: 1.4.18(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0))(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^1.6.9
+        version: 1.6.9(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -226,10 +226,10 @@ importers:
         version: 12.0.3
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0)
+        version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))(zod@4.3.6)
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.4)
@@ -1234,23 +1234,81 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/core@1.4.18':
-    resolution: {integrity: sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==}
+  '@better-auth/core@1.6.9':
+    resolution: {integrity: sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==}
     peerDependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-call: 1.1.8
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.5
       jose: ^6.1.0
       kysely: ^0.28.5
       nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@better-auth/telemetry@1.4.18':
-    resolution: {integrity: sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ==}
+  '@better-auth/drizzle-adapter@1.6.9':
+    resolution: {integrity: sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==}
     peerDependencies:
-      '@better-auth/core': 1.4.18
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
 
-  '@better-auth/utils@0.3.0':
-    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+  '@better-auth/kysely-adapter@1.6.9':
+    resolution: {integrity: sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      kysely: ^0.28.14
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.9':
+    resolution: {integrity: sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.9':
+    resolution: {integrity: sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.9':
+    resolution: {integrity: sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.9':
+    resolution: {integrity: sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.9
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.4.0':
+    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -2608,6 +2666,10 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@pdf-lib/standard-fonts@1.0.0':
     resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
@@ -4868,8 +4930,8 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
-  better-auth@1.4.18:
-    resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
+  better-auth@1.6.9:
+    resolution: {integrity: sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -4878,7 +4940,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4930,8 +4992,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.1.8:
-    resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -7343,8 +7405,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  kysely@0.28.11:
-    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+  kysely@0.28.16:
+    resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
     engines: {node: '>=20.0.0'}
 
   language-subtag-registry@0.3.23:
@@ -7937,8 +7999,8 @@ packages:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
 
-  nanostores@1.1.0:
-    resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
+  nanostores@1.3.0:
+    resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
   napi-postinstall@0.3.4:
@@ -9077,8 +9139,8 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -11568,24 +11630,60 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
+  '@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)':
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.0
+      kysely: 0.28.16
+      nanostores: 1.3.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))':
+  '@better-auth/drizzle-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      drizzle-orm: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0)
+
+  '@better-auth/kysely-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      kysely: 0.28.16
+
+  '@better-auth/memory-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))':
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      mongodb: 6.16.0(@aws-sdk/credential-providers@3.982.0)
+
+  '@better-auth/prisma-adapter@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/telemetry@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+    dependencies:
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.0': {}
+  '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
 
   '@better-fetch/fetch@1.1.21': {}
 
@@ -12611,6 +12709,8 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@pdf-lib/standard-fonts@1.0.0':
     dependencies:
@@ -15053,35 +15153,43 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0))(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.6.9(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))(next@15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))
+      '@better-auth/kysely-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(mongodb@6.16.0(@aws-sdk/credential-providers@3.982.0))
+      '@better-auth/prisma-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       defu: 6.1.4
       jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.0
+      kysely: 0.28.16
+      nanostores: 1.3.0
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.8
-      drizzle-orm: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0)
+      drizzle-orm: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0)
       mongodb: 6.16.0(@aws-sdk/credential-providers@3.982.0)
       next: 15.5.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
-  better-call@1.1.8(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
 
@@ -15847,18 +15955,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0):
+  drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.16.0
       '@upstash/redis': 1.37.0
-      kysely: 0.28.11
+      kysely: 0.28.16
       pg: 8.18.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.11)(pg@8.18.0)
+      drizzle-orm: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)(kysely@0.28.16)(pg@8.18.0)
       zod: 4.3.6
 
   dunder-proto@1.0.1:
@@ -17916,7 +18024,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  kysely@0.28.11: {}
+  kysely@0.28.16: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -18676,7 +18784,7 @@ snapshots:
       - supports-color
     optional: true
 
-  nanostores@1.1.0: {}
+  nanostores@1.3.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -19964,7 +20072,7 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
-  set-cookie-parser@2.7.2: {}
+  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@types/sanitize-html':
         specifier: ^2.16.0
         version: 2.16.0
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       drizzle-kit:
         specifier: ^0.31.8
         version: 0.31.8
@@ -399,6 +402,9 @@ importers:
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
       shadcn:
         specifier: ^4.0.2
         version: 4.0.2(@types/node@20.19.31)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
@@ -5246,6 +5252,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -8636,6 +8647,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
+
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
@@ -8972,6 +8987,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -9112,6 +9130,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -9523,6 +9545,10 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -15437,6 +15463,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
@@ -19403,6 +19438,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qrcode-terminal@0.12.0: {}
+
   qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
@@ -19807,6 +19844,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -20051,6 +20092,8 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -20498,6 +20541,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { getPort } from './lib/get-port.mjs'
+
+const port = getPort()
+const child = spawn('next', ['dev', '--port', String(port)], {
+  stdio: 'inherit',
+  shell: false,
+})
+child.on('exit', code => process.exit(code ?? 0))
+process.on('SIGINT', () => child.kill('SIGINT'))
+process.on('SIGTERM', () => child.kill('SIGTERM'))

--- a/scripts/lib/get-port.mjs
+++ b/scripts/lib/get-port.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export function getPort() {
+  if (process.env.PORT) {
+    return Number(process.env.PORT)
+  }
+  try {
+    const contents = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8')
+    const match = contents.match(/^PORT\s*=\s*(\d+)/m)
+    if (match) {
+      return Number(match[1])
+    }
+  }
+  catch {
+    // .env.local optional — fall through to default
+  }
+  return 3000
+}

--- a/scripts/print-tunnel-qr.mjs
+++ b/scripts/print-tunnel-qr.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+import qrcode from 'qrcode-terminal'
+
+const TUNNEL_STARTUP_DELAY_MS = 3000
+
+function readNgrokUrlFromEnv() {
+  // .env is symlinked at the repo root and used across worktrees
+  const envPath = resolve(process.cwd(), '.env')
+  let contents
+  try {
+    contents = readFileSync(envPath, 'utf8')
+  }
+  catch {
+    return null
+  }
+  const match = contents.match(/^NGROK_URL\s*=\s*(.+)$/m)
+  if (!match) {
+    return null
+  }
+  return match[1].trim().replace(/^['"]|['"]$/g, '')
+}
+
+const url = readNgrokUrlFromEnv()
+if (!url) {
+  console.error('[tunnel-qr] NGROK_URL not found in .env — skipping QR.')
+  process.exit(0)
+}
+
+await sleep(TUNNEL_STARTUP_DELAY_MS)
+
+console.log('')
+console.log(`📱 Mobile tunnel: ${url}`)
+qrcode.generate(url, { small: true })
+console.log('')

--- a/scripts/print-tunnel-qr.mjs
+++ b/scripts/print-tunnel-qr.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 import qrcode from 'qrcode-terminal'
+import { getPort } from './lib/get-port.mjs'
 
 const TUNNEL_STARTUP_DELAY_MS = 3000
 
@@ -29,9 +30,11 @@ if (!url) {
   process.exit(0)
 }
 
+const port = getPort()
+
 await sleep(TUNNEL_STARTUP_DELAY_MS)
 
 console.log('')
-console.log(`📱 Mobile tunnel: ${url}`)
+console.log(`📱 Mobile tunnel: ${url}  →  http://localhost:${port}`)
 qrcode.generate(url, { small: true })
 console.log('')

--- a/scripts/tunnel.mjs
+++ b/scripts/tunnel.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { getPort } from './lib/get-port.mjs'
+
+const NGROK_DOMAIN = 'destined-emu-bold.ngrok-free.app'
+const port = getPort()
+const child = spawn('ngrok', ['http', `--url=${NGROK_DOMAIN}`, String(port)], {
+  stdio: 'inherit',
+  shell: false,
+})
+child.on('exit', code => process.exit(code ?? 0))
+process.on('SIGINT', () => child.kill('SIGINT'))
+process.on('SIGTERM', () => child.kill('SIGTERM'))

--- a/src/shared/components/buttons/account-button.tsx
+++ b/src/shared/components/buttons/account-button.tsx
@@ -3,18 +3,16 @@
 import { BadgeCheckIcon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/shared/components/ui/button'
-import { ROOTS } from '@/shared/config/roots'
 
 interface Props {
   asMenuItem?: boolean
-  absolute?: boolean
 }
 
-export function AccountButton({ asMenuItem = false, absolute }: Props) {
+export function AccountButton({ asMenuItem = false }: Props) {
   const router = useRouter()
 
   function handleClick() {
-    router.push(`${ROOTS.generateUrl('/', { absolute })}/profile}`)
+    router.push('/profile')
   }
 
   return (

--- a/src/shared/components/buttons/billing-button.tsx
+++ b/src/shared/components/buttons/billing-button.tsx
@@ -3,18 +3,16 @@
 import { BadgeCheckIcon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/shared/components/ui/button'
-import { ROOTS } from '@/shared/config/roots'
 
 interface Props {
   asMenuItem?: boolean
-  absolute?: boolean
 }
 
-export function BillingButton({ asMenuItem = false, absolute = false }: Props) {
+export function BillingButton({ asMenuItem = false }: Props) {
   const router = useRouter()
 
   function handleClick() {
-    router.push(`${ROOTS.generateUrl('/', { absolute })}`)
+    router.push('/')
   }
 
   return (

--- a/src/shared/components/buttons/logout-button.tsx
+++ b/src/shared/components/buttons/logout-button.tsx
@@ -2,7 +2,6 @@
 
 import { LogOutIcon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { ROOTS } from '@/shared/config/roots'
 import { signOut } from '@/shared/domains/auth/client'
 import { Button } from '../ui/button'
 
@@ -15,7 +14,7 @@ export function LogoutButton({ asMenuItem = false }: Props) {
 
   async function handleLogout() {
     await signOut()
-    router.push(`${ROOTS.generateUrl('/', ({ absolute: true }))}`)
+    router.push('/')
   }
 
   return (

--- a/src/shared/components/buttons/marketplace-button.tsx
+++ b/src/shared/components/buttons/marketplace-button.tsx
@@ -2,20 +2,18 @@
 
 import { SparkleIcon } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { ROOTS } from '@/shared/config/roots'
 import { Button } from '../ui/button'
 
 interface Props {
   asMenuItem?: boolean
   alternateText?: string
-  absolute?: boolean
 }
 
-export function MarketplaceButton({ asMenuItem = false, alternateText, absolute }: Props) {
+export function MarketplaceButton({ asMenuItem = false, alternateText }: Props) {
   const router = useRouter()
 
   function handleClick() {
-    router.push(`${ROOTS.generateUrl('/', { absolute })}`)
+    router.push('/')
   }
 
   return (

--- a/src/shared/components/navigation/app-sidebar/sidebar-user-button.tsx
+++ b/src/shared/components/navigation/app-sidebar/sidebar-user-button.tsx
@@ -84,16 +84,16 @@ export function SidebarUserButton({
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem className="p-0 cursor-pointer">
-                <MarketplaceButton asMenuItem alternateText="Upgrade to Pro" absolute />
+                <MarketplaceButton asMenuItem alternateText="Upgrade to Pro" />
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem className="p-0 cursor-pointer">
-                <AccountButton asMenuItem absolute />
+                <AccountButton asMenuItem />
               </DropdownMenuItem>
               <DropdownMenuItem className="p-0 cursor-pointer">
-                <BillingButton asMenuItem absolute />
+                <BillingButton asMenuItem />
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />

--- a/src/shared/config/roots.ts
+++ b/src/shared/config/roots.ts
@@ -1,66 +1,68 @@
+export const APP_HOSTS = {
+  prod: ['triprosremodeling.com', 'www.triprosremodeling.com'],
+  dev: ['localhost:3000', 'localhost:3001', 'localhost:3002'],
+  tunnel: ['destined-emu-bold.ngrok-free.app'],
+} as const
+
+const PROD_BASE_URL = `https://${APP_HOSTS.prod[0]}`
+
+interface UrlOptions {
+  absolute?: boolean
+}
+
+function generateUrl(relativeUrl: string, options?: UrlOptions): string {
+  return options?.absolute ? `${PROD_BASE_URL}${relativeUrl}` : relativeUrl
+}
+
 const APP_ROOTS = {
-  devBaseUrl: 'http://localhost:3000',
-  prodBaseUrl: 'https://triprosremodeling.com',
-  authFlow: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/auth-flow', options),
+  authFlow: (options?: UrlOptions) => generateUrl('/auth-flow', options),
   landing: {
-    about: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/about', options),
-    blog: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/blog', options),
-    communityCommitment: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/community/commitment', options),
-    communityJoin: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/community/join', options),
-    contact: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/contact', options),
-    experience: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/experience', options),
-    portfolio: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/portfolio', options),
-    portfolioProjects: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/portfolio/projects', options),
-    portfolioTestimonials: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/portfolio/testimonials', options),
-    services: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/services', options),
-    servicesPillar: (pillarSlug: string, options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/services/${pillarSlug}`, options),
-    servicesTrade: (pillarSlug: string, tradeSlug: string, options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/services/${pillarSlug}/${tradeSlug}`, options),
+    about: (options?: UrlOptions) => generateUrl('/about', options),
+    blog: (options?: UrlOptions) => generateUrl('/blog', options),
+    communityCommitment: (options?: UrlOptions) => generateUrl('/community/commitment', options),
+    communityJoin: (options?: UrlOptions) => generateUrl('/community/join', options),
+    contact: (options?: UrlOptions) => generateUrl('/contact', options),
+    experience: (options?: UrlOptions) => generateUrl('/experience', options),
+    portfolio: (options?: UrlOptions) => generateUrl('/portfolio', options),
+    portfolioProjects: (options?: UrlOptions) => generateUrl('/portfolio/projects', options),
+    portfolioTestimonials: (options?: UrlOptions) => generateUrl('/portfolio/testimonials', options),
+    services: (options?: UrlOptions) => generateUrl('/services', options),
+    servicesPillar: (pillarSlug: string, options?: UrlOptions) => generateUrl(`/services/${pillarSlug}`, options),
+    servicesTrade: (pillarSlug: string, tradeSlug: string, options?: UrlOptions) => generateUrl(`/services/${pillarSlug}/${tradeSlug}`, options),
   },
   dashboard: {
     root: '/dashboard',
     /** @deprecated Use dashboard.pipeline(pipelineKey) instead */
-    pipelines: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/pipeline/fresh', options),
-    pipeline: (pipeline: string = 'fresh', options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/dashboard/pipeline/${pipeline}`, options),
+    pipelines: (options?: UrlOptions) => generateUrl('/dashboard/pipeline/fresh', options),
+    pipeline: (pipeline: string = 'fresh', options?: UrlOptions) => generateUrl(`/dashboard/pipeline/${pipeline}`, options),
     meetings: {
-      root: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/meetings', options),
-      byId: (id: string, options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/dashboard/meetings/${id}`, options),
+      root: (options?: UrlOptions) => generateUrl('/dashboard/meetings', options),
+      byId: (id: string, options?: UrlOptions) => generateUrl(`/dashboard/meetings/${id}`, options),
     },
     proposals: {
-      root: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/proposals', options),
-      new: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/proposals/new', options),
-      byId: (id: string, options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/dashboard/proposals/${id}`, options),
+      root: (options?: UrlOptions) => generateUrl('/dashboard/proposals', options),
+      new: (options?: UrlOptions) => generateUrl('/dashboard/proposals/new', options),
+      byId: (id: string, options?: UrlOptions) => generateUrl(`/dashboard/proposals/${id}`, options),
     },
     projects: {
-      root: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/projects', options),
-      new: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/projects/new', options),
-      byId: (id: string, options?: Parameters<typeof generateUrl>[1]) => generateUrl(`/dashboard/projects/${id}`, options),
+      root: (options?: UrlOptions) => generateUrl('/dashboard/projects', options),
+      new: (options?: UrlOptions) => generateUrl('/dashboard/projects/new', options),
+      byId: (id: string, options?: UrlOptions) => generateUrl(`/dashboard/projects/${id}`, options),
     },
     customers: {
-      root: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/customers', options),
+      root: (options?: UrlOptions) => generateUrl('/dashboard/customers', options),
     },
-    schedule: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/schedule', options),
-    settings: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/settings', options),
-    leadSources: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/lead-sources', options),
-    team: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/team', options),
-    analytics: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/dashboard/analytics', options),
+    schedule: (options?: UrlOptions) => generateUrl('/dashboard/schedule', options),
+    settings: (options?: UrlOptions) => generateUrl('/dashboard/settings', options),
+    leadSources: (options?: UrlOptions) => generateUrl('/dashboard/lead-sources', options),
+    team: (options?: UrlOptions) => generateUrl('/dashboard/team', options),
+    analytics: (options?: UrlOptions) => generateUrl('/dashboard/analytics', options),
   },
   public: {
-    intake: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/intake', options),
-    proposals: (options?: Parameters<typeof generateUrl>[1]) => generateUrl('/proposal-flow', options),
+    intake: (options?: UrlOptions) => generateUrl('/intake', options),
+    proposals: (options?: UrlOptions) => generateUrl('/proposal-flow', options),
   },
 } as const
-
-interface Options {
-  absolute?: boolean
-  isProduction?: boolean
-}
-
-function generateUrl(relativeUrl: string, options?: Options) {
-  // eslint-disable-next-line node/prefer-global/process
-  const domain = process.env.NODE_ENV === 'production' || options?.isProduction ? APP_ROOTS.prodBaseUrl : APP_ROOTS.devBaseUrl
-
-  return options?.absolute ? `${domain}${relativeUrl}` : relativeUrl
-}
 
 export const ROOTS = {
   ...APP_ROOTS,

--- a/src/shared/domains/auth/server.ts
+++ b/src/shared/domains/auth/server.ts
@@ -12,21 +12,15 @@ export const auth = betterAuth({
     schema,
     provider: 'pg',
   }),
-  trustedOrigins: [
-    ...APP_HOSTS.dev.map(h => `http://${h}`),
-    ...APP_HOSTS.tunnel.map(h => `https://${h}`),
-    ...APP_HOSTS.prod.map(h => `https://${h}`),
-  ],
   socialProviders: {
     google: {
       clientId: env.GOOGLE_CLIENT_ID,
       clientSecret: env.GOOGLE_CLIENT_SECRET,
-      // redirectURI intentionally omitted — better-auth derives the OAuth
-      // callback URL per-request (see advanced.trustedProxyHeaders + the absent
-      // baseURL below). Each environment (localhost ports, ngrok tunnel, prod)
-      // gets its own correct callback automatically. APP_HOSTS in roots.ts is
-      // the single source of truth — every host in there must also be
-      // registered in the Google Cloud OAuth Client.
+      // redirectURI omitted — better-auth derives the OAuth callback URL per
+      // request from the baseURL.allowedHosts list below. Each environment
+      // (localhost ports, ngrok tunnel, prod) gets its own correct callback.
+      // APP_HOSTS in roots.ts is the single source of truth — every host in
+      // there must also be registered in the Google Cloud OAuth Client.
       accessType: 'offline',
       prompt: 'select_account consent',
       scope: [
@@ -55,12 +49,19 @@ export const auth = betterAuth({
       },
     },
   },
-  // baseURL intentionally omitted. better-auth derives the per-request base
-  // URL from x-forwarded-host (when trustedProxyHeaders is enabled, e.g.
-  // ngrok/Vercel) or from request.url (e.g. localhost). This makes OAuth
-  // callbacks correct for every host in APP_HOSTS without env juggling.
-  // When we upgrade better-auth to ≥1.5 we can switch to the explicit
-  // `baseURL: { allowedHosts: [...], fallback }` form for stricter validation.
+  // Dynamic baseURL: better-auth picks the per-request origin from the
+  // allowlist below (matched against x-forwarded-host on tunneled/proxied
+  // requests, request.url otherwise). OAuth callbacks, cookies, and redirects
+  // all derive from the resolved host, so localhost (any port), the ngrok
+  // tunnel, and prod each get their own correct URLs without env juggling.
+  // `protocol: 'auto'` derives from x-forwarded-proto; localhost falls back
+  // to http, tunnel/prod to https. allowedHosts entries are auto-added to
+  // trustedOrigins, so we don't duplicate them.
+  baseURL: {
+    allowedHosts: [...APP_HOSTS.dev, ...APP_HOSTS.tunnel, ...APP_HOSTS.prod],
+    protocol: 'auto',
+    fallback: env.NEXT_PUBLIC_BASE_URL,
+  },
   secret: env.BETTER_AUTH_SECRET,
   user: {
     additionalFields: {
@@ -100,14 +101,12 @@ export const auth = betterAuth({
     openAPI(),
   ],
   advanced: {
+    // Cookie domain auto-derives from the resolved request host (per docs).
+    // No `domain` override needed — Vercel canonicalizes www↔apex so each
+    // user only sees one host anyway.
     crossSubDomainCookies: {
       enabled: true,
     },
-    // Trust x-forwarded-host / x-forwarded-proto from the proxy in front of us
-    // (ngrok in dev, Vercel in prod). Required for per-request baseURL
-    // derivation — without this, OAuth callbacks would always point at the
-    // upstream host (localhost:3000) and break mobile testing through the tunnel.
-    trustedProxyHeaders: true,
   },
 })
 

--- a/src/shared/domains/auth/server.ts
+++ b/src/shared/domains/auth/server.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { openAPI } from 'better-auth/plugins'
+import { APP_HOSTS } from '@/shared/config/roots'
 import env from '@/shared/config/server-env'
 import { userRoles } from '@/shared/constants/enums'
 import { db } from '@/shared/db'
@@ -12,19 +13,22 @@ export const auth = betterAuth({
     provider: 'pg',
   }),
   trustedOrigins: [
-    env.BETTER_AUTH_URL || '',
-    env.NEXT_PUBLIC_BASE_URL,
-    'https://triprosremodeling.com',
-    'https://www.triprosremodeling.com',
-  ].filter(Boolean),
+    ...APP_HOSTS.dev.map(h => `http://${h}`),
+    ...APP_HOSTS.tunnel.map(h => `https://${h}`),
+    ...APP_HOSTS.prod.map(h => `https://${h}`),
+  ],
   socialProviders: {
     google: {
       clientId: env.GOOGLE_CLIENT_ID,
       clientSecret: env.GOOGLE_CLIENT_SECRET,
-      redirectURI: `${env.NEXT_PUBLIC_BASE_URL}/api/auth/callback/google`,
+      // redirectURI intentionally omitted — better-auth derives the OAuth
+      // callback URL per-request (see advanced.trustedProxyHeaders + the absent
+      // baseURL below). Each environment (localhost ports, ngrok tunnel, prod)
+      // gets its own correct callback automatically. APP_HOSTS in roots.ts is
+      // the single source of truth — every host in there must also be
+      // registered in the Google Cloud OAuth Client.
       accessType: 'offline',
       prompt: 'select_account consent',
-      // scope is new — first time explicitly configured; adds drive.readonly for Picker
       scope: [
         'openid',
         'email',
@@ -51,7 +55,12 @@ export const auth = betterAuth({
       },
     },
   },
-  baseURL: env.NEXT_PUBLIC_BASE_URL,
+  // baseURL intentionally omitted. better-auth derives the per-request base
+  // URL from x-forwarded-host (when trustedProxyHeaders is enabled, e.g.
+  // ngrok/Vercel) or from request.url (e.g. localhost). This makes OAuth
+  // callbacks correct for every host in APP_HOSTS without env juggling.
+  // When we upgrade better-auth to ≥1.5 we can switch to the explicit
+  // `baseURL: { allowedHosts: [...], fallback }` form for stricter validation.
   secret: env.BETTER_AUTH_SECRET,
   user: {
     additionalFields: {
@@ -94,6 +103,11 @@ export const auth = betterAuth({
     crossSubDomainCookies: {
       enabled: true,
     },
+    // Trust x-forwarded-host / x-forwarded-proto from the proxy in front of us
+    // (ngrok in dev, Vercel in prod). Required for per-request baseURL
+    // derivation — without this, OAuth callbacks would always point at the
+    // upstream host (localhost:3000) and break mobile testing through the tunnel.
+    trustedProxyHeaders: true,
   },
 })
 

--- a/src/shared/entities/proposals/hooks/use-proposal-action-configs.ts
+++ b/src/shared/entities/proposals/hooks/use-proposal-action-configs.ts
@@ -18,7 +18,7 @@ interface ProposalEntity {
 }
 
 function buildShareableUrl(proposalId: string, token: string | null, utmSource: 'email' | 'sms'): string {
-  const base = `${ROOTS.public.proposals({ absolute: true, isProduction: true })}/proposal/${proposalId}`
+  const base = `${ROOTS.public.proposals({ absolute: true })}/proposal/${proposalId}`
   const params = new URLSearchParams()
   if (token) {
     params.set('token', token)

--- a/src/shared/services/email.service.ts
+++ b/src/shared/services/email.service.ts
@@ -16,7 +16,7 @@ function createEmailService() {
       replyTo?: string
       repName?: string
     }) => {
-      const proposalUrl = `${ROOTS.public.proposals({ absolute: true, isProduction: true })}/proposal/${params.proposalId}?token=${params.token}&utm_source=email`
+      const proposalUrl = `${ROOTS.public.proposals({ absolute: true })}/proposal/${params.proposalId}?token=${params.token}&utm_source=email`
       const firstName = params.customerName.split(' ')[0] ?? params.customerName
 
       const { data, error } = await resendClient.emails.send({

--- a/src/shared/services/google-calendar/lib/map-to-gcal.ts
+++ b/src/shared/services/google-calendar/lib/map-to-gcal.ts
@@ -82,7 +82,7 @@ function buildMeetingDescription(meeting: MeetingForGCal): string {
 
   // Schedule deep link — nuqs params trigger scroll + highlight in schedule view
   if (meeting.scheduledFor) {
-    const scheduleBase = ROOTS.dashboard.schedule({ absolute: true, isProduction: true })
+    const scheduleBase = ROOTS.dashboard.schedule({ absolute: true })
     const scheduleUrl = `${scheduleBase}?highlightMeeting=${meeting.id}&highlightDate=${encodeURIComponent(meeting.scheduledFor)}`
     sections.push(`🔗 View in Schedule: ${scheduleUrl}`)
   }

--- a/src/shared/services/resend/emails/proposal-viewed-email.tsx
+++ b/src/shared/services/resend/emails/proposal-viewed-email.tsx
@@ -94,7 +94,7 @@ interface Props {
   proposalId: string
 }
 
-const base = ROOTS.generateUrl('', { absolute: true, isProduction: true })
+const base = ROOTS.generateUrl('', { absolute: true })
 
 export default function ProposalViewedEmail({
   customerName,


### PR DESCRIPTION
## Summary
Closes #98

## Changes
- 6b77029 docs(claude.md): note tunnel-routing semantics for third-party webhooks
- 7b7eaab fix(auth): upgrade better-auth to 1.6.9, use proper allowedHosts pattern
- a259b58 fix(infra): wrap next dev + ngrok in node scripts to honor .env.local PORT
- 4da22eb chore(infra): mobile dev tunnel + roots cleanup (#98)

## Stats
 20 files changed, 661 insertions(+), 130 deletions(-)

## Preview
> Vercel auto-deploys a preview for this PR. Check the deployment status below or the bot comment for the URL.

📱 **Test on mobile** — open the preview URL on your phone to QA.

## Self-Review
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [ ] Vercel preview deployment works
- [ ] Diff reviewed for unintended changes

## Test Plan
- [ ] Verified via Vercel preview