### PR TITLE
fix(zoho-sign): graceful fallback when project has no contract-sent proposal

### DIFF
--- a/docs/zoho-sign/template-inventory.md
+++ b/docs/zoho-sign/template-inventory.md
@@ -96,7 +96,7 @@ API capabilities + recipient unification: see [research-notes.md](./research-not
   | sent-date | CustomDate | `MM/dd/yyyy` | today |
   | start-date | CustomDate | `MMM dd yyyy` | today + 3 days |
   | completion-date | CustomDate | `MMM dd yyyy` | start-date + `validThroughTimeframe` |
-  | original-contract-date | CustomDate | `MMM dd yyyy` | Project's earliest `contractSentAt` across all proposals on all meetings of this project (joined in `getProposal` as `projectFirstContractSentAt`, surfaced as `ctx.originalContractDate`). Falls back to today defensively when missing. |
+  | original-contract-date | CustomDate | `MMM dd yyyy` | Best-available date for the project's first proposal: `COALESCE(MIN(contract_sent_at), MIN(approved_at), MIN(created_at))` across all proposals on all meetings of this project (joined in `getProposal` as `projectFirstContractSentAt`, surfaced as `ctx.originalContractDate`). Falls back to today + `console.warn` only when the project has zero proposals. |
 
 > **Date format quirk:** AWD's `sent-date` accepts `MM/dd/yyyy` while its other CustomDate fields require `MMM dd yyyy`. Sending the wrong format returns HTTP 400 with `code 8033 — Date format is invalid`. The registry uses two distinct field sources (`sentDateSrc` vs `formatZohoShortDate`-based) to handle this.
 

--- a/src/shared/dal/server/proposals/api.ts
+++ b/src/shared/dal/server/proposals/api.ts
@@ -65,18 +65,18 @@ export async function getProposal(proposalId: string) {
       // project. Drives envelope-scenario derivation in
       // src/shared/services/zoho-sign/documents/proposal-context.ts.
       meetingProjectId: meetings.projectId,
-      // Earliest contract_sent_at across all proposals on all meetings
-      // tied to this proposal's project. Drives AWD's
-      // `original-contract-date` field on upsell envelopes (the date
-      // the project's initial agreement was sent). Null when meeting
-      // has no project (initial scenario) — the field is not used in
-      // initial envelopes anyway.
+      // Best-available "original contract date" for this proposal's
+      // project — drives AWD's `original-contract-date` on upsell
+      // envelopes. Falls through `contract_sent_at → approved_at →
+      // created_at` because projects can exist before the original
+      // proposal's contract is sent (project conversion fires on
+      // approval, contract goes out after). Null only when the meeting
+      // has no project (initial scenario, where this field is unused).
       projectFirstContractSentAt: sql<string | null>`(
-        SELECT MIN(p2.contract_sent_at)
+        SELECT COALESCE(MIN(p2.contract_sent_at), MIN(p2.approved_at), MIN(p2.created_at))
         FROM ${proposals} p2
         JOIN ${meetings} m2 ON m2.id = p2.meeting_id
         WHERE m2.project_id = ${meetings.projectId}
-          AND p2.contract_sent_at IS NOT NULL
       )`,
     })
     .from(proposals)

--- a/src/shared/services/zoho-sign/documents/registry.ts
+++ b/src/shared/services/zoho-sign/documents/registry.ts
@@ -60,13 +60,16 @@ const completionDateZohoSrc: FieldSource = (ctx) => {
 
 const sentDateSrc: FieldSource = () => format(new Date(), 'M/d/yyyy')
 
-// AWD-only field — invariant: upsells run on a project that was created
-// when a prior proposal was approved, so `originalContractDate` is always
-// set. Throwing on null surfaces a real data integrity bug instead of
+// AWD-only field. The DAL's projectFirstContractSentAt subquery falls
+// through contract_sent_at → approved_at → created_at, so a non-null
+// value is the norm for upsells. The today-fallback covers the
+// pathological case where the project has zero proposals (data
+// integrity bug) — log it so we notice in production rather than
 // silently shipping today's date as the original contract date.
 const originalContractDateSrc: FieldSource = (ctx) => {
   if (!ctx.originalContractDate) {
-    throw new Error('originalContractDate is null — upsell envelope on a project with no contract-sent proposal')
+    console.warn('originalContractDate is null on upsell envelope — falling back to today; project likely has zero proposals')
+    return format(new Date(), 'MMM dd yyyy')
   }
   return format(ctx.originalContractDate, 'MMM dd yyyy')
 }


### PR DESCRIPTION
## Bug

Hit on the first real dev test of an upsell after #143 deployed:

\`\`\`
Error: originalContractDate is null — upsell envelope on a project with no contract-sent proposal
    at originalContractDateSrc (registry.ts:69)
    at buildMergeSendBody (assemble-envelope.ts:142)
    at assembleEnvelope (assemble-envelope.ts:66)
    at createDraft (contract.service.ts:142)
    at sync-contract-draft.ts (qstash job)
POST /api/qstash-jobs?job=sync-contract-draft 500
\`\`\`

## Root cause

Phase 4.5 assumed: project existence ⇒ at least one proposal in the project has \`contract_sent_at\` set. **That's wrong.** Project conversion fires on proposal **approval**, and approval can happen before the contract has been sent. So there's a real window where \`meeting.projectId\` is non-null but every proposal in the project has \`contract_sent_at = NULL\`.

The hard \`throw\` I added in Phase 4.5 (with the comment "shouldn't happen given the project-creation rule") crashed the QStash sync-contract-draft job on the first upsell drafted against that state.

## Fix

1. **DAL subquery** falls through a chain instead of strict-MIN-of-contract-sent-at:
   \`\`\`sql
   COALESCE(MIN(contract_sent_at), MIN(approved_at), MIN(created_at))
   \`\`\`
   So \`projectFirstContractSentAt\` always surfaces a meaningful date for the project's earliest proposal — even before the original contract has been sent.

2. **\`originalContractDateSrc\`** no longer throws on null. Falls back to today with a \`console.warn\` for the truly-empty case (project with zero proposals — a real data-integrity bug worth logging if it ever happens).

3. **Inventory artifact** updated to document the fallback chain.

## Why this is the right shape

The legal text on AWD references the \"original contract date.\" The cleanest source is \`contract_sent_at\` of the project's first proposal. When that's not yet set, \`approved_at\` is the next-best — the date the homeowner formally agreed to the original terms. \`created_at\` is the last-resort proxy. The agent can still manually override the field on the Zoho draft before sending if needed (same affordance Zoho gives for every field).

## Self-review

- \`pnpm tsc --noEmit\` clean
- \`pnpm lint\` clean
- \`pnpm tsx scripts/verify-evaluate-documents.ts\` 11/11 pass

## Test plan

- [ ] Upsell proposal against a project whose original proposal was approved but not yet contract-sent → draft creates successfully, \`original-contract-date\` filled with original proposal's \`approved_at\`
- [ ] Upsell against a project whose original was contract-sent → draft creates successfully, field filled with original proposal's \`contract_sent_at\` (unchanged from #143 behavior)
- [ ] Initial sale envelope unaffected (field not used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)