### PR TITLE
fix(zoho-sign): self-heal envelope selection + retune AWD inline-SOW threshold

### DIFF
--- a/docs/zoho-sign/template-inventory.md
+++ b/docs/zoho-sign/template-inventory.md
@@ -199,4 +199,5 @@ These appear in the [`envelopeDocumentIds`](../../src/shared/constants/enums/zoh
 | senior-ack | * | TBD |
 | esign-waiver | * | TBD |
 | material-order | * | TBD |
-| awd | * | TBD (post-author) |
+| awd | sow | 2000 (Zoho hard cap 2048; SOW_INLINE_MAX_CHARS drops 48 for margin — single field, no second field to overflow into like sow-1/sow-2) |
+| awd | * (other fields) | TBD |

--- a/src/shared/services/zoho-sign/constants/index.ts
+++ b/src/shared/services/zoho-sign/constants/index.ts
@@ -77,11 +77,14 @@ export const ZOHO_SIGN_TEMPLATES = {
 export const SOW_FIELD_MAX_CHARS = 2000
 
 /**
- * Threshold (in plaintext chars) above which the signing request routes
- * to the long path (attached SOW PDF) instead of inlining into sow-1/sow-2.
+ * Threshold (in plaintext chars) above which the upsell envelope routes to
+ * an attached SOW PDF instead of inlining into AWD's single `sow` text
+ * field. Drives both `awd.sow` mapping (empty vs filled) and the
+ * `sow-pdf` upsell requirement — must stay consistent across both.
  *
- * Derived: 2 × SOW_FIELD_MAX_CHARS = 4000 theoretical short-path capacity,
- * minus ~10% headroom so a paragraph-boundary break never falls outside
- * the cap. Auditable, not magic.
+ * Calibrated for AWD's single text field (Zoho hard cap 2048; we leave
+ * the same 48-char margin as SOW_FIELD_MAX_CHARS). The legacy 2-field
+ * packing (sow-1 + sow-2 on base/senior templates) supported ~3600 chars
+ * inline; AWD has no second field, so the threshold drops to 2000.
  */
-export const SOW_INLINE_MAX_CHARS = 3600
+export const SOW_INLINE_MAX_CHARS = 2000

--- a/src/shared/services/zoho-sign/documents/assemble-envelope.ts
+++ b/src/shared/services/zoho-sign/documents/assemble-envelope.ts
@@ -1,9 +1,9 @@
 import type { Buffer } from 'node:buffer'
 import type { EnvelopeDocument, ProposalContext } from './types'
 import type { EnvelopeDocumentId } from '@/shared/constants/enums'
-import { ZOHO_SIGN_BASE_URL } from '../constants'
+import { SOW_INLINE_MAX_CHARS, ZOHO_SIGN_BASE_URL } from '../constants'
 import { getZohoAccessToken } from '../lib/get-access-token'
-import { validateEnvelopeSelection } from './evaluate'
+import { evaluateDocuments } from './evaluate'
 import { ENVELOPE_DOCUMENTS } from './registry'
 
 interface ZohoMergeSendResponse {
@@ -38,18 +38,45 @@ interface AssembleResult {
  * recipient (verified in Phase 1's smoke tests). Field data is global
  * per envelope: identical labels across templates fill once.
  *
- * Throws on invalid selection (missing required / forbidden present)
- * via validateEnvelopeSelection. On Zoho API failure, attempts cleanup
- * via deleteRequest before rethrowing so the QStash retry isn't stuck
- * with a half-built envelope.
+ * Self-heals against context drift: required docs are determined by
+ * registry rules at assembly time (not by saved selection), so a SOW
+ * that grew past the inline threshold, a threshold change, or any other
+ * predicate flip after the agent saved auto-includes the now-required
+ * docs. The saved selection is treated as the agent's *optional*
+ * preferences — it's intersected with currently-optional docs and
+ * unioned with currently-required docs.
+ *
+ * On Zoho API failure, attempts cleanup via deleteRequest before
+ * rethrowing so the QStash retry isn't stuck with a half-built envelope.
  */
 export async function assembleEnvelope(ctx: ProposalContext): Promise<AssembleResult> {
-  const selection = ctx.proposal.formMetaJSON.envelopeDocumentIds ?? []
-  validateEnvelopeSelection(ctx, selection)
+  const savedSelection = new Set(ctx.proposal.formMetaJSON.envelopeDocumentIds ?? [])
+  const evaluation = evaluateDocuments(ctx)
+  const optionalSet = new Set(evaluation.optional)
+
+  // Effective envelope: all currently-required + saved-optionals that are
+  // still applicable. Anything saved that's now forbidden is silently
+  // dropped; anything required but not previously saved is silently added.
+  const effectiveIds = new Set<EnvelopeDocumentId>([
+    ...evaluation.required,
+    ...[...savedSelection].filter(id => optionalSet.has(id)),
+  ])
+
+  const drift = computeDrift(savedSelection, effectiveIds, evaluation)
+  if (drift.added.length > 0 || drift.dropped.length > 0) {
+    console.warn('[zoho-sign] envelope selection drifted from saved — self-healing', {
+      proposalId: ctx.proposal.id,
+      scenario: ctx.scenario,
+      saved: [...savedSelection],
+      effective: [...effectiveIds],
+      added: drift.added,
+      dropped: drift.dropped,
+    })
+  }
 
   // Canonicalize order against the registry — agent-submitted order is
   // ignored; envelope documents render in the registry's declared order.
-  const orderedDocs = ENVELOPE_DOCUMENTS.filter(d => selection.includes(d.id))
+  const orderedDocs = ENVELOPE_DOCUMENTS.filter(d => effectiveIds.has(d.id))
   const templateDocs = orderedDocs.filter(d => d.source.kind === 'zoho-template')
   const pdfDocs = orderedDocs.filter(d => d.source.kind === 'generated-pdf')
 
@@ -64,6 +91,10 @@ export async function assembleEnvelope(ctx: ProposalContext): Promise<AssembleRe
   // template_ids=[...]&data={...}&is_quicksend=false. See
   // docs/zoho-sign/research-notes.md for the full API shape.
   const mergeBody = buildMergeSendBody(ctx, templateDocs)
+  // Pre-flight diagnostics: prints field lengths + threshold so a stale
+  // dev server (or unexpected text field bloat) is immediately visible
+  // without waiting for Zoho to fail.
+  logMergeSendDiagnostics(ctx, mergeBody)
   const mergeRes = await fetch(`${ZOHO_SIGN_BASE_URL}/api/v1/templates/mergesend`, {
     method: 'POST',
     headers: {
@@ -73,7 +104,29 @@ export async function assembleEnvelope(ctx: ProposalContext): Promise<AssembleRe
     body: mergeBody,
   })
   if (!mergeRes.ok) {
-    throw new Error(`Zoho mergesend failed (${mergeRes.status}): ${await mergeRes.text()}`)
+    const responseText = await mergeRes.text()
+    // Log the full request payload alongside the response so we can diagnose
+    // field-validation / action-id / template-id mismatches without re-running.
+    console.error('[zoho-sign] mergesend failed', {
+      status: mergeRes.status,
+      response: responseText,
+      proposalId: ctx.proposal.id,
+      scenario: ctx.scenario,
+      templateIds: templateDocs.flatMap(d => d.source.kind === 'zoho-template' ? [d.source.zohoTemplateId] : []),
+      requestBody: mergeBody,
+    })
+    let zohoCode: number | undefined
+    let zohoMessage: string | undefined
+    try {
+      const parsed = JSON.parse(responseText) as { code?: number, message?: string }
+      zohoCode = parsed.code
+      zohoMessage = parsed.message
+    }
+    catch {}
+    const detail = zohoCode != null
+      ? `code ${zohoCode} — ${zohoMessage ?? responseText}`
+      : responseText
+    throw new Error(`Zoho mergesend failed (${mergeRes.status}): ${detail}`)
   }
   const mergeJson = (await mergeRes.json()) as ZohoMergeSendResponse
   const requestId = mergeJson.requests?.request_id
@@ -224,4 +277,59 @@ async function deleteRequest(token: string, requestId: string): Promise<void> {
 
 function sanitizeFilename(name: string): string {
   return name.replace(/[\\/]/g, '_').replace(/\s+/g, '_').slice(0, 200)
+}
+
+/**
+ * Reports what the assembler self-healed: `added` are docs the rules now
+ * require that the agent's saved selection didn't include; `dropped` are
+ * docs the agent had saved that are no longer applicable (forbidden or
+ * required-when-false). Used purely for warn-logging — the assembler
+ * doesn't act on it; effectiveIds is already correct.
+ */
+function computeDrift(
+  saved: Set<EnvelopeDocumentId>,
+  effective: Set<EnvelopeDocumentId>,
+  evaluation: ReturnType<typeof evaluateDocuments>,
+): { added: EnvelopeDocumentId[], dropped: EnvelopeDocumentId[] } {
+  const added = [...effective].filter(id => !saved.has(id))
+  const forbiddenSet = new Set(evaluation.forbidden)
+  const optionalSet = new Set(evaluation.optional)
+  const dropped = [...saved].filter(id => forbiddenSet.has(id) || (!effective.has(id) && !optionalSet.has(id)))
+  return { added, dropped }
+}
+
+/**
+ * Pre-flight pretty-print of the merge body. Surfaces stale-bundle
+ * issues (threshold mismatch) and unexpected field lengths before Zoho
+ * has a chance to reject them with cryptic codes.
+ */
+function logMergeSendDiagnostics(ctx: ProposalContext, mergeBody: string): void {
+  const params = new URLSearchParams(mergeBody)
+  const dataRaw = params.get('data')
+  if (!dataRaw) {
+    return
+  }
+  try {
+    const parsed = JSON.parse(dataRaw) as {
+      templates?: { field_data?: { field_text_data?: Record<string, string>, field_date_data?: Record<string, string> } }
+    }
+    const textData = parsed.templates?.field_data?.field_text_data ?? {}
+    const dateData = parsed.templates?.field_data?.field_date_data ?? {}
+    const fieldLengths = Object.fromEntries(
+      Object.entries(textData).map(([k, v]) => [k, v.length]),
+    )
+    console.warn('[zoho-sign] mergesend pre-flight', {
+      proposalId: ctx.proposal.id,
+      scenario: ctx.scenario,
+      sowTextLength: ctx.sowText.length,
+      isLongSow: ctx.isLongSow,
+      sowInlineMaxChars: SOW_INLINE_MAX_CHARS,
+      textFieldLengths: fieldLengths,
+      dateFields: dateData,
+      templateIds: params.get('template_ids'),
+    })
+  }
+  catch (err) {
+    console.warn('[zoho-sign] diagnostics parse failed', err)
+  }
 }


### PR DESCRIPTION
## Summary

Two production-bug fixes in the composable-templates envelope path, both surfaced while testing upsell envelope creation in dev:

1. **Self-healing assembler** — required docs are derived from registry rules at assembly time, not from the agent's saved selection. Saved selection is now treated as the agent's optional preferences only.
2. **`SOW_INLINE_MAX_CHARS` 3600 → 2000** — calibrated for AWD's single `sow` field (Zoho hard cap 2048), not the retired 2-field legacy packing (sow-1 + sow-2).

## Why this matters

Both bugs blocked upsell envelope creation:

**Stale selection (rejected at validation):**
```
Error [EnvelopeSelectionError]: Invalid envelope selection — missing required: sow-pdf
```
Triggered when the agent saved `envelopeDocumentIds` and then *something* about the proposal context drifted before the QStash job dispatched (SOW grew past threshold, age changed, predicate code refactored).

**SOW too long (rejected by Zoho API):**
```
Error: Zoho mergesend failed (400): {"code":9011,"error_param":"sow","message":"You have entered too many characters","status":"failure"}
```
Triggered for any SOW between 2001–3600 chars on the upsell path. Old threshold gated against legacy 2-field capacity; AWD only has one `sow` field.

## Changes

### `assemble-envelope.ts` — self-healing
- Drops `validateEnvelopeSelection` from the assembly path
- Computes `effective = current_required ∪ (saved ∩ current_optional)`
- Logs `[zoho-sign] envelope selection drifted from saved — self-healing` with `{added, dropped, saved, effective}` whenever drift is detected
- Pre-flight diagnostic logging from earlier session retained — surfaces field lengths + threshold + scenario before Zoho call so the next failure has actionable context without re-running

### `constants/index.ts` — threshold retune
- `SOW_INLINE_MAX_CHARS` 3600 → 2000
- Comment updated to explain the calibration (single AWD field, Zoho 2048 hard cap, 48-char margin matching `SOW_FIELD_MAX_CHARS`)

### `template-inventory.md` — doc the cap
- AWD `sow` field max-chars captured as 2000 (was "TBD post-author")

### Untouched (separate concerns)
- `validateEnvelopeSelection` still used by `configureDraftEnvelope` mutation at SAVE time — that path is correct because the agent is acting on currently-displayed rules
- The legacy non-registry envelope-creation path in `contract.service.ts:146-167` (Phase 6 cleanup) is out of scope

## Self-Review

- [x] `pnpm tsc --noEmit` clean
- [x] Verified end-to-end in dev via QStash + ngrok tunnel (upsell with SOW > 2000 chars now successfully assembles + attaches sow-pdf + sets AWD sow='')
- [x] Drift warning fires once when retrying a stale-saved proposal, then assembles correctly
- [x] Pre-flight diagnostic logging confirmed showing correct `sowInlineMaxChars: 2000`, `isLongSow: true`, `textFieldLengths.sow: 0` after fix

## Test Plan

- [ ] Deploy to Vercel preview → smoke-test upsell envelope creation
- [ ] Confirm initial-sale envelope still works (regression check)
- [ ] Watch prod logs after merge for `[zoho-sign] envelope selection drifted` warnings — expected on the first send for any proposal saved before this PR

## Related

- PR #138 — composable templating scaffolding
- PR #140 — registry-driven envelope assembler
- PR #143 — `original-contract-date` wiring
- PR #150 — `original-contract-date` graceful fallback (immediate predecessor)
- Issue #148 — agreement-section UI/UX overhaul (now has comment #4 about agent agency / scenario suggestion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)