### PR TITLE
fix(query-toolbar): polish date-range filter calendar + popover layout

### DIFF
--- a/src/shared/components/query-toolbar/ui/filter-controls/date-range-filter-control.tsx
+++ b/src/shared/components/query-toolbar/ui/filter-controls/date-range-filter-control.tsx
@@ -12,6 +12,8 @@ import { useState } from 'react'
 import { Button } from '@/shared/components/ui/button'
 import { Calendar } from '@/shared/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/components/ui/popover'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/components/ui/select'
+import { useIsMobile } from '@/shared/hooks/use-mobile'
 import { cn } from '@/shared/lib/utils'
 
 interface Props {
@@ -31,6 +33,7 @@ function fmtRangeLabel(value: DateRange | undefined, fallback: string): string {
 
 export function DateRangeFilterControl({ definition, value, onChange }: Props) {
   const [open, setOpen] = useState(false)
+  const isMobile = useIsMobile()
 
   const calendarSelected: ReactDayPickerRange | undefined = value
     ? {
@@ -58,6 +61,8 @@ export function DateRangeFilterControl({ definition, value, onChange }: Props) {
     })
   }
 
+  const hasPresets = (definition.presets?.length ?? 0) > 0
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -71,19 +76,20 @@ export function DateRangeFilterControl({ definition, value, onChange }: Props) {
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-auto p-0">
-        {definition.presets && definition.presets.length > 0 && (
-          <div className="flex flex-wrap gap-1 border-b border-border/50 p-2">
-            {definition.presets.map(preset => (
-              <Button
-                key={preset.value}
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handlePreset(preset.value)}
-              >
-                {preset.label}
-              </Button>
-            ))}
+        {hasPresets && (
+          <div className="flex items-center justify-between gap-2 border-b border-border/50 p-2">
+            <Select onValueChange={handlePreset}>
+              <SelectTrigger size="sm" className="flex-1">
+                <SelectValue placeholder="Quick range…" />
+              </SelectTrigger>
+              <SelectContent>
+                {definition.presets!.map(preset => (
+                  <SelectItem key={preset.value} value={preset.value}>
+                    {preset.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             {value && (
               <Button
                 type="button"
@@ -100,7 +106,8 @@ export function DateRangeFilterControl({ definition, value, onChange }: Props) {
           mode="range"
           selected={calendarSelected}
           onSelect={handleCalendarChange}
-          numberOfMonths={2}
+          numberOfMonths={isMobile ? 1 : 2}
+          showOutsideDays={isMobile}
         />
       </PopoverContent>
     </Popover>

--- a/src/shared/components/ui/calendar.tsx
+++ b/src/shared/components/ui/calendar.tsx
@@ -108,7 +108,7 @@ function Calendar({
         range_middle: cn('rounded-none', defaultClassNames.range_middle),
         range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
         today: cn(
-          'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
+          'bg-primary/10 rounded-md outline-2 outline-primary -outline-offset-2 data-[selected=true]:bg-transparent data-[selected=true]:outline-0 data-[selected=true]:rounded-none',
           defaultClassNames.today,
         ),
         outside: cn(


### PR DESCRIPTION
## Summary
Follow-up polish for the date-range filter shipped in #155.

- **Today styling** — was solid `bg-accent`, indistinguishable from selected dates. Now light tint + outline (`bg-primary/10` + `outline-2 outline-primary -outline-offset-2`); cleared when today falls inside a selected range so range styling owns the cell.
- **Popover layout** — preset row was a `flex-wrap` of buttons that grew wider than the 2-month calendar, leaving empty space to the right of the second month. Replaced with a `Select` dropdown ("Quick range…") + `Clear` button pushed to the end via `justify-between`. Popover is now sized to the calendar.
- **Responsive months** — 2 months + `showOutsideDays=false` on desktop (kills the duplicate-today / duplicate-selected cells at month boundaries shown in the screenshot); 1 month + outside days visible on mobile (no duplication possible there).

## Test plan
- [ ] Open any table with a date-range filter (Activities / Past Meetings / Past Proposals / Lead Source customers).
- [ ] Today is outlined with light tint, not filled blue.
- [ ] Pick a range that crosses today — today merges into range styling, no double-highlight.
- [ ] Pick a range that crosses a month boundary — only one cell per date (no duplicate selected day appearing in the adjacent month).
- [ ] Preset dropdown + Clear button align tidily; popover width matches the calendar.
- [ ] Mobile viewport: 1 calendar month, outside days render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)