### PR TITLE
fix(gcal): full customer↔meeting↔calendar sync overhaul via QStash jobs

### DIFF
--- a/docs/codebase-conventions/service-architecture.md
+++ b/docs/codebase-conventions/service-architecture.md
@@ -89,6 +89,62 @@ Provider functions accept and return provider-native types (`ZohoEnvelope`, `QbI
 **Reference impl**: `src/shared/services/providers/zoho-sign/client.ts`
 **Enforced by**: convention
 
+### background-side-effects-via-qstash-jobs
+
+Side effects fired from a tRPC mutation, a Route Handler, or an Entity hook (`spec.hooks.{op}.{before,after}`) MUST go through a QStash job declared with `createJob` from `@/shared/services/providers/upstash/lib/create-job`. **Never** raw `void promise.catch(...)`. **Never** `after()` from `next/server` for anything you actually care about landing.
+
+```ts
+// 1. Declare the job in src/shared/services/providers/upstash/jobs/
+import { schedulingService } from '@/shared/services/scheduling.service'
+import { createJob } from '../lib/create-job'
+
+export const syncMeetingToGcalJob = createJob(
+  'sync-meeting-to-gcal',
+  async (payload: { meetingId: string }) => {
+    await schedulingService.syncMeeting(payload.meetingId)
+  },
+)
+
+// 2. Register it in src/app/api/qstash-jobs/route.ts (jobs array)
+
+// 3. Dispatch from the call site
+// CRITICAL work (silent loss = bug):
+await syncMeetingToGcalJob.dispatchOrThrow({ meetingId: row.id })
+
+// COSMETIC work (silent loss = OK):
+void optimizeImageJob.dispatch({ mediaFileId: created.id })
+```
+
+**Why**: on Vercel, a function instance terminates once the response is sent. Raw fire-and-forget (`void promise.catch()`) gets killed mid-flight. `after()` from `next/server` extends the instance lifetime but is still **best-effort** — no retries, cancelled on route timeout, lost on function crash. This was the latent bug behind sean@'s missing GCal events for intake-created meetings. QStash provides durability: the dispatch persists in Upstash before the function returns, automatic retries with exponential backoff on downstream failure, dead-letter on exhaustion. The cost is one round-trip (~50-200ms) to enqueue.
+
+**`dispatch` vs `dispatchOrThrow` — pick by criticality**:
+
+| Variant | Behavior on QStash transport failure | When to use |
+|---|---|---|
+| `dispatchOrThrow` | Throws — caller's mutation fails with 500 | Data integrity, calendar sync, time-changed pushes, anything where silent loss is a bug |
+| `dispatch` | Logs + swallows — caller's mutation still returns 200 | Cosmetic / non-critical: image optimization, view-tracking pings, "you were added" courtesy notifications, analytics events |
+
+Use `dispatchOrThrow` and `await` it for critical work. Use `dispatch` and `void` it for cosmetic work — the explicit `void` documents the fire-and-forget intent at the call site.
+
+**Required**:
+- Handler MUST be idempotent. QStash retries automatically on non-2xx — running the handler twice must be safe. Most natural patterns are already idempotent (GCal etag-conditional pushes, DELETE-with-404-tolerance, customer-projection re-walks).
+- Payload MUST be a small JSON-serializable object — typically just ids. Reconstruct heavy state inside the handler from a fresh DB read.
+- Critical-path callers (`dispatchOrThrow`) MUST `await` the dispatch in series — never wrap in `void`. The whole point is to surface enqueue failures to the user.
+- Multiple parallel dispatches in the same hook: collect promises and `Promise.all` them so the dispatch round-trips share latency. See `meetingServerSpec.hooks.update.after` for the canonical pattern.
+
+**When NOT to enqueue a job**:
+- The user must see the outcome of the side effect in the same response — `await` the operation inline.
+- Pure realtime fan-out (e.g. `ably.channels.get(...).publish(...)`). The whole point of Ably is sub-100ms broadcast; routing through QStash adds 100-300ms of dispatch latency and defeats the use case. Use inline `await ably.publish(...)`. Same goes for any other ephemeral pub/sub.
+- The work is so cheap it's not worth the round-trip (a synchronous `db.update` for one row, a single cache invalidation).
+
+**Anti-pattern: `after()` from `next/server`**. Do not use. It looks like background work but is best-effort with no durability. Either the work is critical (use `dispatchOrThrow`) or it's so ephemeral that inline `await` is acceptable. There is no middle ground we trust.
+
+**Reference impl**: `src/shared/services/providers/upstash/jobs/sync-meeting-to-gcal.ts` + `delete-meeting-event.ts` + `propagate-customer-change.ts` + `notify-meeting-time-changed.ts`, dispatched from `meetingServerSpec.hooks.{create,update,delete}` and `customerServerSpec.hooks.update.after`.
+
+**Enforced by**: convention (PR review). Audit greps:
+- `rg "import\s*\{[^}]*\bafter\b[^}]*\}\s*from\s*['\"]next/server['\"]" src` — should return zero matches.
+- `rg "void [a-zA-Z]+.*\.catch" src/shared/entities src/trpc src/shared/services` — every match should either be a `void *.dispatch(...).catch(...)` (cosmetic job) or a candidate for migration to `dispatchOrThrow`.
+
 ## Current classification
 
 **Internal services:** `contracts`, `scheduling`, `email`, `notification`, `media`, `accounting`, `construction-data`, `pdf`, `ai`, `analytics`, `webhook`.
@@ -106,6 +162,9 @@ Provider functions accept and return provider-native types (`ZohoEnvelope`, `QbI
 - **Provider A importing from Provider B.** Use a service to orchestrate.
 - **Pure-local utility (no HTTP) in `services/providers/`.** Move to `shared/lib/`.
 - **Domain types (`Proposal`, `Customer`) in a provider's `client.ts` signatures.** Translate in `lib/` instead.
+- **Nesting `schemas/` inside `lib/`.** `schemas/` is always a sibling of `lib/`, matching the entity/feature/domain pattern. See `provider-directory-shape`.
+- **`void something.catch(console.error)` to fire-and-forget a critical side effect from a tRPC mutation, route handler, or entity hook.** Use a QStash job — see `background-side-effects-via-qstash-jobs`. Raw fire-and-forget gets killed mid-flight on Vercel and silently drops the work. (Cosmetic work — image optimization, analytics — is still a valid `void job.dispatch(...)`.)
+- **`import { after } from 'next/server'` for background work.** Best-effort with no retries; if you care whether the work landed, it's a QStash job. If you don't care, it's an inline `await` (cheap) or a `void job.dispatch(...)` (so the dispatch itself survives function shutdown).
 
 ## See also
 

--- a/docs/plans/2026-06-01-gcal-sync-handoff.md
+++ b/docs/plans/2026-06-01-gcal-sync-handoff.md
@@ -1,0 +1,280 @@
+# Session Handoff: GCal Sync — Cron Schedule + Pre-Commit Review
+
+> Date: 2026-06-01 | Branch: `main` (working tree uncommitted)
+> Predecessor session: GCal sync architectural overhaul (5 steps, all in working tree)
+
+## Why this matters
+
+A previous session shipped a 5-step overhaul that fixes the systemic GCal sync bugs:
+
+- sean@ creating intake meetings → events never landing on info@'s master calendar (sean@'s 32/59 meetings had no GCal event; info@ and oliver@ had 0 misses)
+- Customer name/address changes → events embedding stale customer data with no propagation
+- Meeting deletion → orphan events lingering on the master calendar
+- Inbound GCal→app sync flaky (likely channel-expiry related, no automated renewal)
+
+The overhaul is in working tree, type-checks clean (`pnpm tsc`), lints clean (`pnpm lint` — only pre-existing warnings remain in `date-time-picker.tsx`, `optimized-image.tsx`, `push-subscription-banner.tsx`). **Nothing is committed yet.**
+
+You have two tasks:
+
+1. **Review every change** for correctness, edge cases, and conventions adherence before commit.
+2. **Schedule the renewal cron** — the one deferred deliverable that keeps inbound sync alive long-term.
+
+---
+
+## Task 1 — Review the GCal-fix changes
+
+### How to get oriented
+
+```bash
+git status                  # see all modified + new files in working tree
+git diff                    # the full diff
+```
+
+Some unmodified files in the working tree are NOT part of this work (voip docs, `.gitignore`, `src/shared/config/server-env.ts`, voip enums, `src/shared/db/schema/customers.ts` voip columns, `docs/plans/voip-*.md`). Those belong to a parallel VoIP session — **do not touch them**.
+
+### Files that ARE part of this work
+
+**Schema + UI (hotfix carryover from earlier)**
+- `src/shared/db/schema/meetings.ts` — `scheduled_for.notNull()`
+- `src/shared/entities/meetings/components/create-meeting-form.tsx` — required-field UI on the date picker
+- `docs/codebase-conventions/service-architecture.md` — new `background-side-effects-via-qstash-jobs` rule + anti-pattern (replaced an interim `background-side-effects-via-after` rule in a follow-up session — `after()` proved unreliable for critical work)
+
+**Step 1 — Meeting hook parity**
+- `src/shared/entities/meetings/lib/server-spec.ts` — `update.after` reads `row.ownerId` not `ctx.session!.user.id`; all three side effects (`syncMeeting`, `notifyMeetingScheduledTimeChanged`, ably publish) wrapped in `after()`; `duplicate.overrides` defensive
+- `src/shared/services/notification.service.ts` — `notifyMeetingScheduledTimeChanged.excludeUserId` is now optional
+
+**Step 2 — `pushToGCal` split into named entry points**
+- `src/shared/services/scheduling.service.ts` — `pushToGCal` removed; replaced by `syncMeeting(meetingId)`, `deleteMeetingEvent({gcalEventId})`, `propagateCustomerChange(customerId)`, `syncActivity(userId, activityId)`. Two new module-private helpers: `resolveSystemCalendarAuth()` and `pushMeetingEventToCalendar()`.
+- `src/shared/entities/meetings/dal/server/google-calendar.ts` — new DAL function `getMeetingsForCustomerWithGCalEvent(customerId)`
+- Callers migrated: `src/shared/entities/meetings/lib/server-spec.ts`, `src/trpc/routers/schedule.router/sync.router.ts`, `src/trpc/routers/meetings.router/participants.router.ts`, `src/trpc/routers/schedule.router/activities.router.ts`, `scripts/rebuild-gcal-descriptions.ts`
+
+**Step 3 — Meeting seam end-to-end (writes + delete hook + customer cascade)**
+- `src/shared/entities/meetings/lib/server-spec.ts` — `projectId` added to update.after trigger set; new `delete.before` hook captures `gcalEventId` + fires `deleteMeetingEvent` via `after()`
+- `src/shared/entities/customers/lib/server-spec.ts` — delete cascade routes through `meetingCrud.delete` per meeting (was raw `tx.delete(meetings)`); transaction dropped (`meetingCrud.delete` isn't tx-aware)
+- `src/shared/entities/meetings/dal/server/mutations.ts` — `deriveOutcomeOnProposalSent` routes through `meetingCrud.update` (with the `OVERWRITABLE_OUTCOMES` pre-check kept as raw SELECT since entity API has no compare-and-set)
+- `src/features/customer-pipelines/dal/server/move-customer-to-pipeline.ts` — bulk pipeline-pipeline write loops through `meetingCrud.update(SYSTEM_CONTEXT, ...)` per row
+- `src/trpc/routers/projects.router/business.router.ts` — project-creation meeting update routes through `meetingCrud.update(buildUserContext, ...)`
+
+**Step 4 — Customer→event propagation**
+- `src/shared/entities/customers/lib/server-spec.ts` — new `hooks.update.after` fires `propagateCustomerChange` via `after()`. NO field filter (decision T2 with the user — every customer update fires; `propagateCustomerChange` short-circuits if customer has no synced events). Contains an `@migration(ably-realtime-kernel)` placeholder for the future Ably emit.
+
+**Step 5 — Inbound sync observability + scheduling docs**
+- `src/trpc/routers/schedule.router/sync.router.ts` — new `systemOwnerHealth` query + `renewSystemOwnerChannel` mutation (both super-admin gated)
+- `src/shared/services/providers/upstash/jobs/sync-calendars.ts` — scheduling-requirements docblock
+
+**Also touched**
+- `src/trpc/routers/customers.router/business.router.ts` — `createFromIntake` got a BAD_REQUEST guard on missing `scheduledFor` for `customer_and_meeting` mode (the schema is NOT NULL now)
+
+### Review priorities
+
+Walk through these in order. Read the file + read the diff + check the listed concerns.
+
+1. **`src/shared/entities/meetings/lib/server-spec.ts`** — the central nervous system. Confirm:
+   - `create.after` uses `row.ownerId` ✓
+   - `update.after` uses `row.ownerId` ✓
+   - `update.after` trigger set includes `scheduledFor || meetingType || agentNotes || projectId` ✓
+   - `delete.before` queries `gcalEventId` and schedules `deleteMeetingEvent` via `after()`
+   - `duplicate.overrides` falls back to `source.ownerId` for SYSTEM_CONTEXT
+
+2. **`src/shared/entities/customers/lib/server-spec.ts`** — the upstream trigger. Confirm:
+   - `hooks.update.before` geocode invalidation untouched (this was pre-existing)
+   - `hooks.update.after` is NEW, fires `propagateCustomerChange` via `after()`, no field filter
+   - `hooks.delete.before` cascades through `meetingCrud.delete(SYSTEM_CONTEXT, ...)` per meeting — DOUBLE-CHECK the transaction-was-dropped tradeoff is acceptable for your team
+
+3. **`src/shared/services/scheduling.service.ts`** — the operations layer. Confirm:
+   - `syncMeeting(meetingId)` — no `userId` param (the swap-to-system-owner is internal)
+   - `propagateCustomerChange` short-circuits BEFORE `resolveSystemCalendarAuth` if no synced meetings exist (avoids `console.error` noise on every customer update in dev)
+   - `deleteMeetingEvent({ gcalEventId })` exists and uses `resolveSystemCalendarAuth` + `googleCalendarClient.deleteEvent` (which already swallows 404 at the provider layer)
+   - `syncActivity(userId, activityId)` — keeps per-user calendar semantics
+   - Two module-private helpers (`resolveSystemCalendarAuth`, `pushMeetingEventToCalendar`) sit above `createSchedulingService` and are NOT exported
+
+4. **All migrated meeting-write callers** — confirm each compiles + the migration preserves semantics:
+   - `src/features/customer-pipelines/dal/server/move-customer-to-pipeline.ts` — loops `meetingCrud.update(SYSTEM_CONTEXT, ...)`. Cost: N round-trips instead of 1. Justified by hook-firing.
+   - `src/shared/entities/meetings/dal/server/mutations.ts` — `deriveOutcomeOnProposalSent` uses `meetingCrud.update(ctx, ...)` with the OVERWRITABLE_OUTCOMES pre-check. Confirm: the SELECT-then-UPDATE flow is correct (no race window concern given the small invocation surface).
+   - `src/trpc/routers/projects.router/business.router.ts` — uses `buildUserContext(ctx.session.user.id, ctx.session.user.role, meetingServerSpec)`. Confirm: the calling agent IS expected to be a participant in the meeting they're converting to a project. If not, the update silently no-ops.
+
+5. **`src/trpc/routers/customers.router/business.router.ts`** — the intake flow. Confirm:
+   - BAD_REQUEST guard at top for `customer_and_meeting && !leadMetaJSON?.scheduledFor`
+   - `meetingCrud.create(SYSTEM_CONTEXT, { ownerId: ownerId!, ..., scheduledFor: scheduledFor! })` — both non-null assertions are guarded by the BAD_REQUEST check
+
+6. **`src/shared/services/notification.service.ts`** — `excludeUserId` optional. Confirm the `ne(...) : undefined` ternary preserves the original participant-recipient logic when an actor IS provided.
+
+### Verification commands
+
+```bash
+pnpm tsc                    # should be clean
+pnpm lint                   # should be clean (pre-existing warnings OK; no errors in our files)
+git diff --stat             # eyeball the touched-files list against the section above
+```
+
+### Manual smoke (recommended before commit)
+
+The full end-to-end is hard to test without a real GCal account. Minimum smoke:
+
+1. Spin up `pnpm dev`
+2. As sean@ (or any agent), open a customer profile and create a meeting via "Add Meeting" → confirm meeting appears
+3. Open the GCal calendar UI for info@triprosremodeling.com → confirm event landed
+4. Edit the customer's address from the agent dashboard → confirm the event's location updates within ~10s (the `after()` background work)
+5. Delete the meeting → confirm the event disappears from info@'s calendar
+
+If you can't run the full smoke, at minimum confirm `pnpm tsc` + `pnpm lint` and the schema migration:
+
+```bash
+# Dev DB already has scheduled_for NOT NULL applied manually (see earlier session).
+# Verify:
+psql $DATABASE_DEV_URL -c "\d meetings" | grep scheduled_for
+# expected: scheduled_for | timestamp with time zone | not null
+```
+
+---
+
+## Task 2 — Schedule the renewal cron
+
+### Why this is the load-bearing remaining item
+
+Google Calendar push channels expire on a 7-day max. Without renewal:
+1. Inbound webhooks stop firing
+2. The app silently stops receiving GCal edits (datetime moves in GCal don't propagate to the app)
+3. The user reported this exact bug ("two-way datetime sync used to work, now broken")
+
+`syncCalendarsJob` exists and does the right thing (loop all accounts, inbound sync + `renewChannelIfNeeded`). It's registered at `/api/qstash-jobs?job=sync-calendars` and ready to fire. **The only missing piece is the trigger.**
+
+See the docblock on `src/shared/services/providers/upstash/jobs/sync-calendars.ts` — it lays out the two options. Pick one and ship it.
+
+### Option A (recommended) — QStash schedule
+
+The existing `/api/qstash-jobs` route already verifies QStash signatures and dispatches to handlers by `?job=<key>`. To run on a schedule, configure QStash to send a recurring POST.
+
+**Two ways to register the schedule:**
+
+**A1. QStash dashboard** (zero code, click-ops):
+- Go to https://console.upstash.com/qstash → Schedules → Create
+- Destination URL: `${NEXT_PUBLIC_BASE_URL}/api/qstash-jobs?job=sync-calendars`
+- HTTP method: POST
+- Body: `{}` (empty JSON)
+- Cron: `0 */12 * * *` (every 12h — channel expiry window is 24h pre-end, so ≤24h cadence keeps things evergreen; 12h leaves headroom for a missed tick)
+- Save
+
+**A2. Programmatic schedule via `qstashClient`** (in-source, repeatable across environments):
+
+`@upstash/qstash` SDK supports `schedules.create(...)`. Add a one-time setup script:
+
+```ts
+// scripts/setup-gcal-cron.ts (NEW)
+import { qstashClient } from '@/shared/services/providers/upstash/qstash-client'
+import { getPublicBaseUrl } from '@/shared/config/public-url'
+import './lib/load-env'   // matches convention from memory/feedback-scripts-load-env.md
+
+async function main() {
+  const result = await qstashClient.schedules.create({
+    destination: `${getPublicBaseUrl()}/api/qstash-jobs?job=sync-calendars`,
+    cron: '0 */12 * * *',
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  console.log('Scheduled:', result.scheduleId)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+Run once per environment (`NODE_ENV=production` with prod DATABASE_URL):
+
+```bash
+DRIZZLE_TARGET=prod pnpm tsx scripts/setup-gcal-cron.ts
+```
+
+Document the script in `package.json` if you want `pnpm gcal:cron:setup` convenience.
+
+**Either way:** verify the schedule fired by querying `scheduleRouter.sync.systemOwnerHealth` after ~12h. `channelExpiresAt` should always be > 24h in the future.
+
+### Option B — Vercel Cron (alternative)
+
+Use this if you'd rather not rely on QStash for scheduling. Requires a new env var and a new route.
+
+```jsonc
+// vercel.json (NEW)
+{
+  "crons": [
+    { "path": "/api/cron/sync-calendars", "schedule": "0 */12 * * *" }
+  ]
+}
+```
+
+```ts
+// src/shared/config/server-env.ts — add to the schema:
+CRON_SECRET: z.string(),
+```
+
+```ts
+// src/app/api/cron/sync-calendars/route.ts (NEW)
+import env from '@/shared/config/server-env'
+import { syncCalendarsJob } from '@/shared/services/providers/upstash/jobs/sync-calendars'
+
+export const maxDuration = 60
+
+export async function GET(request: Request) {
+  const auth = request.headers.get('authorization')
+  if (auth !== `Bearer ${env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  await syncCalendarsJob.handler({})
+  return new Response('ok')
+}
+```
+
+Add `CRON_SECRET` to Vercel project env vars (any high-entropy string; Vercel will inject it on the cron call).
+
+**Note**: a parallel VoIP session has uncommitted edits to `src/shared/config/server-env.ts` in the working tree. If you go with Option B, coordinate the env-schema edit so you don't collide with their work.
+
+### Decision rationale
+
+| Factor | Option A (QStash) | Option B (Vercel Cron) |
+|---|---|---|
+| Code surface | 0 new files (dashboard) OR 1 setup script | 2 new files + 1 env var |
+| Env vars | None | New `CRON_SECRET` |
+| Source-of-truth | Dashboard (A1) OR script (A2) | `vercel.json` |
+| Conflicts with parallel VoIP work | None | Touches `server-env.ts` |
+| Existing infra reuse | Uses `/api/qstash-jobs` already in place | New route |
+
+**Recommended: Option A2** (programmatic QStash). Smallest source-controlled footprint, no env-schema collisions, replays cleanly across environments.
+
+### After scheduling
+
+1. Hit `scheduleRouter.sync.systemOwnerHealth` from the dashboard (or via curl/tRPC dev tools). Confirm `connected: true`, `channelExpired: false`, `hasSyncToken: true`.
+2. Wait for one cron tick (or trigger manually via QStash console → "Run now").
+3. Re-check health. `channelExpiresAt` should now be ~7 days out.
+4. Optional: edit a meeting's start time directly in GCal → wait <2 minutes → confirm the meeting row's `scheduled_for` updated in the DB (`SELECT scheduled_for FROM meetings WHERE id = '<known meeting>'`).
+
+### Once scheduled, retire the docblock TODO
+
+Update `src/shared/services/providers/upstash/jobs/sync-calendars.ts` — replace the "Scheduling required" block with a one-liner stating the current schedule:
+
+```
+Scheduled via QStash at <schedule_id> (every 12h). See scripts/setup-gcal-cron.ts.
+```
+
+---
+
+## Prior-session decisions (locked, do not re-litigate)
+
+These were grilled in the predecessor session. Treat as binding unless you find a concrete reason to revisit:
+
+- **T1**: GCal event title/location/description are RENDERINGS of in-app data. Edits in GCal silently overwritten on next propagation. Only `scheduledFor` is two-way. (Feature, not a bug.)
+- **T2**: No field filter inside `customer.update.after`. Every customer update fires `propagateCustomerChange`. Short-circuit is at the service layer (no synced meetings → no work).
+- **T3**: Customer delete cascade flows through `meetingCrud.delete` (not raw `db.delete`). Transactional atomicity dropped. Partial-failure is acceptable per pre-existing comment.
+- **T4**: Meeting `hooks.create.before` is session-conditional (already in main as of commit `512dab19`). SYSTEM_CONTEXT callers (like `createFromIntake`) supply ownerId in input.
+- **T5**: Ably realtime emit deferred. `@migration(ably-realtime-kernel)` placeholder in customer `update.after` points at the future addition.
+
+## Commit strategy suggestion
+
+Five natural commit slices map to the 5 steps; use `git add -p` if you want them separate. Or one big commit titled `feat(gcal): full customer↔meeting↔calendar sync overhaul` — your call. The hotfix carryover (schema NOT NULL + form UI + service-architecture.md doc) is a logical sixth slice but can also fold into the first commit since it's the foundation everything else builds on.
+
+## What's intentionally OUT of scope for this handoff
+
+- **The Meeting entity full migration to the Entity Server System.** Meeting already has a `meetingServerSpec` + `meetingCrud` from PR #209. This session relied on that being in place. If you find anything that requires deeper meeting-entity-router work, that's a separate PR.
+- **Orphan-GCal-event sweeper script.** The meeting `delete.before` uses `after()` (best-effort). If the Google API call fails after row deletion, the event lingers. A future sweeper script could find events on info@'s calendar with no matching DB meeting row and clean them up. Out of scope here.
+- **Field-filter optimization in `customer.update.after`.** Per T2 decision. Revisit when/if accounting service or another high-frequency writer creates noticeable load.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "migrate:proposal-kind:dev": "tsx scripts/migrate-proposal-kind.ts",
     "rebuild:gcal": "NODE_ENV=production NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
     "rebuild:gcal:dev": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/rebuild-gcal-descriptions.ts",
+    "gcal:cron:setup": "NODE_ENV=production NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/setup-gcal-cron.ts",
+    "gcal:cron:setup:dev": "NODE_OPTIONS=\"--conditions=react-server\" tsx scripts/setup-gcal-cron.ts",
     "meta": "tsx scripts/meta/index.ts",
     "dispatch": "bash scripts/dispatch.sh",
     "tunnel": "node scripts/tunnel.mjs",

--- a/scripts/rebuild-gcal-descriptions.ts
+++ b/scripts/rebuild-gcal-descriptions.ts
@@ -39,7 +39,6 @@
 import './lib/load-env'
 import { isNotNull } from 'drizzle-orm'
 import { clearMeetingGCalFields, updateMeetingGCalFields } from '@/shared/entities/meetings/dal/server/google-calendar'
-import { getSystemOwnerId } from '@/shared/entities/users/dal/server/system'
 import { db } from '@/shared/db'
 import { meetings } from '@/shared/db/schema/meetings'
 import { schedulingService } from '@/shared/services/scheduling.service'
@@ -74,8 +73,6 @@ async function main() {
   console.log(`DB host:  ${host}`)
   console.log('')
 
-  const systemOwnerId = await getSystemOwnerId()
-
   const rows = await db
     .select({ id: meetings.id })
     .from(meetings)
@@ -100,7 +97,7 @@ async function main() {
 
   for (const [index, m] of rows.entries()) {
     try {
-      await schedulingService.pushToGCal(systemOwnerId, 'meeting', m.id)
+      await schedulingService.syncMeeting(m.id)
       success += 1
     }
     catch (err) {

--- a/scripts/setup-gcal-cron.ts
+++ b/scripts/setup-gcal-cron.ts
@@ -1,0 +1,142 @@
+/**
+ * One-time setup for the Google Calendar renewal cron.
+ *
+ * Schedules a recurring QStash POST against `/api/qstash-jobs?job=sync-calendars`
+ * so that `syncCalendarsJob` fires automatically. The job loops every account
+ * with a linked GCal calendar and:
+ *   1. Pulls inbound changes (catches edits made directly in the GCal UI),
+ *   2. Renews each account's webhook channel if it's within 24h of expiry.
+ *
+ * Without this schedule, channels expire on a 7-day max and inbound webhooks
+ * silently stop firing — which is the failure mode behind the "two-way
+ * datetime sync used to work, now broken" report.
+ *
+ * Cadence: every 12 hours (see CRON below). The renewal-eligibility window
+ * is 24h pre-expiry, so any cadence ≤24h keeps channels evergreen; 12h
+ * leaves headroom for a missed tick.
+ *
+ * Run once per environment. Idempotent in the sense that the script lists
+ * existing schedules pointing at the same destination URL before creating;
+ * if one already exists the script bails (delete the old one in the QStash
+ * dashboard, or run with `--force` to create a duplicate).
+ *
+ * Usage:
+ *   pnpm gcal:cron:setup:dev               # dry-run, dev (uses ngrok tunnel)
+ *   pnpm gcal:cron:setup:dev -- --apply    # create dev schedule
+ *   pnpm gcal:cron:setup                   # dry-run, prod
+ *   pnpm gcal:cron:setup -- --apply        # create prod schedule
+ *   ... -- --apply --force                 # bypass dupe guard
+ *
+ * URL resolution:
+ *   Uses `getPublicBaseUrl()` — the canonical helper from public-url.ts.
+ *   That returns `NGROK_URL ?? NEXT_PUBLIC_BASE_URL`. In dev, NGROK_URL is
+ *   set in .env.local and the cron fires against the tunnel (QStash needs
+ *   a public HTTPS destination — localhost can't work). In prod NGROK_URL
+ *   is unset and we fall through to NEXT_PUBLIC_BASE_URL.
+ *
+ * Safety guards:
+ *   - QSTASH_TOKEN unset → server-env.ts crashes the import, before any call.
+ *   - NODE_ENV=production AND resolved URL contains "ngrok"|"localhost"|
+ *     "127.0.0.1" → refuse. Defends against the prod-script-invoked-from-
+ *     dev-worktree footgun (where .env.local would otherwise leak NGROK_URL
+ *     into a prod schedule).
+ *   - dev mode AND resolved URL is plain http://localhost → refuse with a
+ *     hint to start ngrok. QStash cannot deliver to localhost.
+ *
+ * The `--conditions=react-server` Node flag (set by the pnpm script) makes
+ * `server-only` resolve to its no-op `empty.js` export, which lets this CLI
+ * import the `qstashClient` provider without the Next.js webpack alias that
+ * normally provides that behavior inside the running app.
+ */
+import './lib/load-env'
+
+import { getPublicBaseUrl } from '@/shared/config/public-url'
+import { qstashClient } from '@/shared/services/providers/upstash/qstash-client'
+
+const CRON = '0 */12 * * *'
+const JOB_KEY = 'sync-calendars'
+
+function assertReachableDestination(url: string, isProd: boolean): void {
+  const looksDev = /ngrok|localhost|127\.0\.0\.1/i.test(url)
+  if (isProd && looksDev) {
+    console.error('')
+    console.error(`✗ Refusing: NODE_ENV=production but resolved URL looks dev-ish: ${url}`)
+    console.error('  This usually means .env.local has NGROK_URL set and is leaking into a prod')
+    console.error('  invocation. Run from an environment where only NEXT_PUBLIC_BASE_URL (the prod')
+    console.error('  origin) is exported, or unset NGROK_URL for this invocation.')
+    process.exit(1)
+  }
+  if (!isProd && url.startsWith('http://')) {
+    console.error('')
+    console.error(`✗ Refusing: resolved URL is plain HTTP: ${url}`)
+    console.error('  QStash only delivers to HTTPS endpoints and cannot reach localhost. Start')
+    console.error('  the ngrok tunnel (`pnpm tunnel`) so NGROK_URL is populated, then re-run.')
+    process.exit(1)
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply')
+  const force = process.argv.includes('--force')
+
+  const baseUrl = getPublicBaseUrl()
+  const isProd = process.env.NODE_ENV === 'production'
+  const destination = `${baseUrl}/api/qstash-jobs?job=${JOB_KEY}`
+
+  console.log('--- SETUP GCAL RENEWAL CRON ---')
+  console.log(`Mode:        ${apply ? 'APPLY' : 'dry-run (pass --apply to create)'}`)
+  console.log(`NODE_ENV:    ${process.env.NODE_ENV ?? '(unset)'}`)
+  console.log(`Base URL:    ${baseUrl}`)
+  console.log(`Destination: ${destination}`)
+  console.log(`Cron:        ${CRON} (every 12h)`)
+  console.log('')
+
+  assertReachableDestination(baseUrl, isProd)
+
+  // List existing schedules and warn on duplicates before mutating.
+  const existing = await qstashClient.schedules.list()
+  const dupes = existing.filter(s => s.destination === destination)
+
+  if (dupes.length > 0) {
+    console.warn(`⚠️  Found ${dupes.length} existing schedule(s) pointing at this destination:`)
+    for (const s of dupes) {
+      console.warn(`   - scheduleId=${s.scheduleId}  cron="${s.cron}"  paused=${s.isPaused}`)
+    }
+    if (!force) {
+      console.warn('')
+      console.warn('Refusing to create a duplicate. Delete the existing schedule in the')
+      console.warn('QStash dashboard (https://console.upstash.com/qstash) or re-run with')
+      console.warn('--force to create another. Aborting.')
+      process.exit(1)
+    }
+    console.warn('--force set — proceeding to create another anyway.')
+    console.warn('')
+  }
+
+  if (!apply) {
+    console.log('Dry run — no schedule created. Re-run with --apply to commit.')
+    process.exit(0)
+  }
+
+  const result = await qstashClient.schedules.create({
+    destination,
+    cron: CRON,
+    method: 'POST',
+    body: JSON.stringify({}),
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  console.log('')
+  console.log('--- CREATED ---')
+  console.log(`scheduleId: ${result.scheduleId}`)
+  console.log('')
+  console.log('Verify the next tick fires by either:')
+  console.log('  - Watching the QStash dashboard "Last delivery" timestamp tick over')
+  console.log('  - Calling scheduleRouter.sync.systemOwnerHealth and confirming')
+  console.log('    channelExpiresAt advances ~7d every 12h')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/qstash-jobs/route.ts
+++ b/src/app/api/qstash-jobs/route.ts
@@ -2,12 +2,16 @@ import type { Job, JobMap } from '@/shared/services/providers/upstash/types'
 import { Receiver } from '@upstash/qstash'
 import env from '@/shared/config/server-env'
 import { createQbRecordsJob } from '@/shared/services/providers/upstash/jobs/create-qb-records'
+import { deleteMeetingEventJob } from '@/shared/services/providers/upstash/jobs/delete-meeting-event'
 import { generateAISummaryJob } from '@/shared/services/providers/upstash/jobs/generate-ai-summary'
 import { initialCalendarSyncJob } from '@/shared/services/providers/upstash/jobs/initial-calendar-sync'
+import { notifyMeetingTimeChangedJob } from '@/shared/services/providers/upstash/jobs/notify-meeting-time-changed'
 import { optimizeImageJob } from '@/shared/services/providers/upstash/jobs/optimize-image'
+import { propagateCustomerChangeJob } from '@/shared/services/providers/upstash/jobs/propagate-customer-change'
 import { sendViewNotificationJob } from '@/shared/services/providers/upstash/jobs/send-view-notification'
 import { syncCalendarsJob } from '@/shared/services/providers/upstash/jobs/sync-calendars'
 import { syncCustomersJob } from '@/shared/services/providers/upstash/jobs/sync-customers'
+import { syncMeetingToGcalJob } from '@/shared/services/providers/upstash/jobs/sync-meeting-to-gcal'
 import { syncQbInvoiceJob } from '@/shared/services/providers/upstash/jobs/sync-qb-invoice'
 import { syncQbPaymentJob } from '@/shared/services/providers/upstash/jobs/sync-qb-payment'
 import { syncZohoSignStatusJob } from '@/shared/services/providers/upstash/jobs/sync-zoho-sign-status'
@@ -29,6 +33,10 @@ const jobs: Job[] = [
   syncZohoSignStatusJob,
   syncCalendarsJob,
   initialCalendarSyncJob,
+  syncMeetingToGcalJob,
+  deleteMeetingEventJob,
+  propagateCustomerChangeJob,
+  notifyMeetingTimeChangedJob,
 ]
 
 /**

--- a/src/features/customer-pipelines/dal/server/move-customer-to-pipeline.ts
+++ b/src/features/customer-pipelines/dal/server/move-customer-to-pipeline.ts
@@ -2,22 +2,36 @@ import type { MeetingPipeline } from '@/shared/constants/enums/pipelines'
 
 import { and, eq, isNull } from 'drizzle-orm'
 
+import { dalVerifySuccess } from '@/shared/dal/server/lib/helpers'
+import { SYSTEM_CONTEXT } from '@/shared/dal/server/types'
 import { db } from '@/shared/db'
 import { meetings } from '@/shared/db/schema/meetings'
+import { meetingCrud } from '@/shared/entities/meetings/dal/server/crud'
 
 /**
  * Moves all of a customer's non-project meetings to a target pipeline.
  * Only affects meetings with no projectId (project meetings stay in "projects" pipeline).
+ *
+ * Routes through `meetingCrud.update` so the entity's update hook fires
+ * per row — `pipeline` isn't itself a GCal-affecting field, but the hook
+ * also broadcasts an Ably refresh so open meeting cards repaint. The
+ * caller (`customer-pipelines.router.ts:moveCustomerToPipeline`) gates
+ * on `manage:CustomerPipeline` (super-admin only), so SYSTEM_CONTEXT is
+ * appropriate here.
  */
 export async function moveCustomerToPipeline(
   customerId: string,
   pipeline: MeetingPipeline,
 ): Promise<void> {
-  await db
-    .update(meetings)
-    .set({ pipeline })
+  const meetingIds = await db
+    .select({ id: meetings.id })
+    .from(meetings)
     .where(and(
       eq(meetings.customerId, customerId),
       isNull(meetings.projectId),
     ))
+
+  for (const m of meetingIds) {
+    dalVerifySuccess(await meetingCrud.update(SYSTEM_CONTEXT, { id: m.id, data: { pipeline } }))
+  }
 }

--- a/src/shared/db/schema/meetings.ts
+++ b/src/shared/db/schema/meetings.ts
@@ -26,7 +26,7 @@ export const meetings = pgTable('meetings', {
   meetingOutcome: meetingOutcomeEnum('meeting_outcome').notNull().default('not_set'),
   pipeline: meetingPipelineEnum('pipeline').notNull().default('fresh'),
   projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
-  scheduledFor: timestamp('scheduled_for', { mode: 'string', withTimezone: true }),
+  scheduledFor: timestamp('scheduled_for', { mode: 'string', withTimezone: true }).notNull(),
   contextJSON: jsonb('context_json').$type<MeetingContext>(),
   flowStateJSON: jsonb('flow_state_json').$type<MeetingFlowState>(),
   agentNotes: text('agent_notes'),

--- a/src/shared/entities/customers/lib/server-spec.ts
+++ b/src/shared/entities/customers/lib/server-spec.ts
@@ -3,6 +3,8 @@ import type { EntityServerSpec } from '@/shared/dal/server/types'
 import { eq, inArray } from 'drizzle-orm'
 import { z } from 'zod'
 
+import { dalVerifySuccess } from '@/shared/dal/server/lib/helpers'
+import { SYSTEM_CONTEXT } from '@/shared/dal/server/types'
 import { db } from '@/shared/db'
 import {
   customers,
@@ -13,6 +15,8 @@ import {
 } from '@/shared/db/schema'
 import { CUSTOMER } from '@/shared/entities/customers/lib/constants'
 import { customerVisibility } from '@/shared/entities/customers/lib/visibility'
+import { meetingCrud } from '@/shared/entities/meetings/dal/server/crud'
+import { propagateCustomerChangeJob } from '@/shared/services/providers/upstash/jobs/propagate-customer-change'
 
 // Updates allow `createdAt` (super-admin-only via CASL field gate) — legacy
 // Notion imports land with import-day timestamps and lead-source stats by
@@ -77,31 +81,72 @@ export const customerServerSpec = {
           geocodedAt: null,
         }
       },
+      // Propagate every customer update to the customer's downstream
+      // projections — today: GCal events for the customer's meetings (name,
+      // address, phone, email are rendered into the event summary/location/
+      // description). No field filter on purpose: `propagateCustomerChange`
+      // short-circuits inside the job handler when the customer has zero
+      // meetings with gcalEventId, so the cost on irrelevant updates is one
+      // QStash enqueue + one cheap DB read inside the job. Field-CASL on
+      // crud.update already restricts agents to JSON profile columns, so the
+      // vast majority of writes won't reach the system-calendar-auth path.
+      //
+      // Strict dispatch: a missed enqueue means every synced GCal event
+      // continues rendering stale customer data with no recovery hook —
+      // surface as a 500 instead.
+      //
+      // @migration(ably-realtime-kernel) — when the Ably realtime kernel
+      // lands, also publish a `customer:<row.id>` channel event inline (NOT
+      // via QStash — ephemeral realtime fan-out is the same exception as
+      // meeting.updated in meetings/lib/server-spec.ts):
+      //   await ably.channels.get(`customer:${row.id}`).publish(
+      //     'customer.updated', { fields: Object.keys(meta.input) })
+      //
+      // see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
+      async after(row, _ctx, _meta) {
+        await propagateCustomerChangeJob.dispatchOrThrow({ customerId: row.id })
+      },
     },
     delete: {
       // The schema's FK behavior for meetings.customerId and proposals.meetingId
       // is `set null` on parent delete — without this hook, deleting a customer
       // would orphan rows that surface in lists with no owner. Manually delete
-      // proposals → meetings in the same logical step before the customer row
-      // is removed. customer_notes and projects cascade via schema FKs.
-      // The cascade tx commits before the parent customer delete runs. If the
-      // parent delete fails after the cascade succeeds, the customer row survives
-      // with children gone — recoverable by retry (the no-children re-run is a
-      // clean no-op).
-      // Was previously inlined in dal/server/queries.ts:deleteCustomer.
+      // proposals → meetings before the customer row is removed. customer_notes
+      // and projects cascade via schema FKs.
+      //
+      // Meeting deletes go through `meetingCrud.delete` so each meeting's
+      // `delete` hook fires — that hook is responsible for one-way GCal event
+      // cleanup. SYSTEM_CONTEXT because the caller has already passed
+      // `delete:Customer` (super-admin manage:all) at the tRPC layer; the
+      // cascade should not be re-gated by per-row participation.
+      //
+      // No transaction wraps the cascade: meetingCrud.delete is not tx-aware,
+      // and the original "atomic cascade" comment was tolerant of partial
+      // failure anyway. Partial failure mode: some meetings deleted (with their
+      // GCal events) before a later failure leaves the rest plus the customer
+      // intact — retry is a clean no-op for already-deleted meetings.
+      //
+      // Proposals are still cleared with a raw `db.delete` because the proposal
+      // delete hook (if any) wouldn't cascade to GCal — only meetings do.
+      // When proposalServerSpec grows a delete hook with cross-system effects,
+      // revisit and route through proposalCrud.delete per row.
       async before(id, _ctx) {
         const customerId = String(id)
-        await db.transaction(async (tx) => {
-          const customerMeetings = await tx
-            .select({ id: meetings.id })
-            .from(meetings)
-            .where(eq(meetings.customerId, customerId))
-          const meetingIds = customerMeetings.map(m => m.id)
-          if (meetingIds.length > 0) {
-            await tx.delete(proposals).where(inArray(proposals.meetingId, meetingIds))
-            await tx.delete(meetings).where(inArray(meetings.id, meetingIds))
-          }
-        })
+        const customerMeetings = await db
+          .select({ id: meetings.id })
+          .from(meetings)
+          .where(eq(meetings.customerId, customerId))
+
+        if (customerMeetings.length === 0) {
+          return
+        }
+
+        const meetingIds = customerMeetings.map(m => m.id)
+        await db.delete(proposals).where(inArray(proposals.meetingId, meetingIds))
+
+        for (const m of customerMeetings) {
+          dalVerifySuccess(await meetingCrud.delete(SYSTEM_CONTEXT, { id: m.id }))
+        }
       },
     },
   },

--- a/src/shared/entities/meetings/components/create-meeting-form.tsx
+++ b/src/shared/entities/meetings/components/create-meeting-form.tsx
@@ -84,7 +84,10 @@ export function CreateMeetingForm({
   )
 
   const isPending = createMutation.isPending || updateMutation.isPending
-  const canSubmit = meetingType && (!isProjectType || projectId) && !isPending
+  // scheduledFor is required — a meeting without a time isn't a meeting. The
+  // central-calendar push hook also depends on it. Gating here keeps the rule
+  // visible at the surface; server schema + DB NOT NULL enforce it for real.
+  const canSubmit = meetingType && !!scheduledFor && (!isProjectType || projectId) && !isPending
 
   function handleSubmit() {
     if (!canSubmit) {
@@ -96,7 +99,7 @@ export function CreateMeetingForm({
         id: editMeetingId,
         data: {
           meetingType,
-          scheduledFor: scheduledFor?.toISOString(),
+          scheduledFor: scheduledFor.toISOString(),
           flowStateJSON: tradeSelections.length > 0
             ? { tradeSelections }
             : undefined,
@@ -107,7 +110,7 @@ export function CreateMeetingForm({
       createMutation.mutate({
         customerId,
         meetingType,
-        scheduledFor: scheduledFor?.toISOString(),
+        scheduledFor: scheduledFor.toISOString(),
         flowStateJSON: tradeSelections.length > 0
           ? { tradeSelections }
           : undefined,
@@ -190,7 +193,7 @@ export function CreateMeetingForm({
         <Label>
           Date & time
           {' '}
-          <span className="text-muted-foreground text-xs font-normal">(optional)</span>
+          <span className="text-destructive">*</span>
         </Label>
         <DateTimePicker
           value={scheduledFor}

--- a/src/shared/entities/meetings/dal/server/google-calendar.ts
+++ b/src/shared/entities/meetings/dal/server/google-calendar.ts
@@ -1,6 +1,6 @@
 import type { MeetingForGCal } from '@/shared/services/providers/google-calendar/lib/map-to-gcal'
 
-import { eq, isNotNull } from 'drizzle-orm'
+import { and, eq, isNotNull } from 'drizzle-orm'
 import { db } from '@/shared/db'
 import { customers } from '@/shared/db/schema/customers'
 import { meetings } from '@/shared/db/schema/meetings'
@@ -66,6 +66,23 @@ export async function getAllMeetingsWithSchedule(): Promise<{ id: string }[]> {
     .where(isNotNull(meetings.scheduledFor))
 }
 
+/**
+ * Find meetings of a single customer that have an existing GCal event.
+ * Used by `schedulingService.propagateCustomerChange` to re-sync the
+ * customer's event projections after any customer mutation.
+ */
+export async function getMeetingsForCustomerWithGCalEvent(
+  customerId: string,
+): Promise<{ id: string }[]> {
+  return db
+    .select({ id: meetings.id })
+    .from(meetings)
+    .where(and(
+      eq(meetings.customerId, customerId),
+      isNotNull(meetings.gcalEventId),
+    ))
+}
+
 export async function getMeetingByGCalEventId(gcalEventId: string) {
   return db.query.meetings.findFirst({
     where: eq(meetings.gcalEventId, gcalEventId),
@@ -104,7 +121,7 @@ export async function clearAllMeetingGCalFields(): Promise<void> {
 
 export async function updateMeetingScheduledFor(
   meetingId: string,
-  scheduledFor: string | null,
+  scheduledFor: string,
 ): Promise<void> {
   await db.update(meetings)
     .set({ scheduledFor })

--- a/src/shared/entities/meetings/dal/server/mutations.ts
+++ b/src/shared/entities/meetings/dal/server/mutations.ts
@@ -1,34 +1,47 @@
 // Meetings business mutations. see ../../DOCS.md for business rules.
 // DAL conventions: docs/codebase-conventions/dal-conventions.md
-// @migration(meetings-entity-router) — currently called with SYSTEM_CONTEXT from
-// the proposals delivery router; will get a sibling queries.ts when meetings
-// migrates to the entity server system.
 
 import type { DalReturn, ScopedContext } from '@/shared/dal/server/types'
 
-import { and, eq, inArray } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 
-import { dalDbOperation } from '@/shared/dal/server/lib/helpers'
+import { dalDbOperation, dalVerifySuccess } from '@/shared/dal/server/lib/helpers'
 import { db } from '@/shared/db'
 import { meetings } from '@/shared/db/schema'
+import { meetingCrud } from '@/shared/entities/meetings/dal/server/crud'
 
 const OVERWRITABLE_OUTCOMES = ['not_set', 'proposal_created'] as const
 
 /**
  * Conditionally flips a meeting's outcome to `proposal_sent`.
+ *
+ * Routes through `meetingCrud.update` so the entity hook fires (pipeline
+ * derivation in update.before, ably broadcast in update.after). The flip
+ * is conditional on the current outcome being in OVERWRITABLE_OUTCOMES —
+ * that pre-check stays a raw SELECT here rather than relying on hooks,
+ * since the entity API doesn't have a "compare-and-set" primitive.
+ *
  * see ../../DOCS.md#outcome-flips-on-proposal-sent
  */
 export async function deriveOutcomeOnProposalSent(
-  _ctx: ScopedContext,
+  ctx: ScopedContext,
   input: { meetingId: string },
 ): Promise<DalReturn<void>> {
   return dalDbOperation(async () => {
-    await db
-      .update(meetings)
-      .set({ meetingOutcome: 'proposal_sent' })
-      .where(and(
-        eq(meetings.id, input.meetingId),
-        inArray(meetings.meetingOutcome, [...OVERWRITABLE_OUTCOMES]),
-      ))
+    const [row] = await db
+      .select({ outcome: meetings.meetingOutcome })
+      .from(meetings)
+      .where(eq(meetings.id, input.meetingId))
+      .limit(1)
+
+    if (!row || !(OVERWRITABLE_OUTCOMES as readonly string[]).includes(row.outcome)) {
+      // Outcome is past the overwritable window — no-op.
+      return
+    }
+
+    dalVerifySuccess(await meetingCrud.update(ctx, {
+      id: input.meetingId,
+      data: { meetingOutcome: 'proposal_sent' },
+    }))
   })
 }

--- a/src/shared/entities/meetings/lib/server-spec.ts
+++ b/src/shared/entities/meetings/lib/server-spec.ts
@@ -1,6 +1,9 @@
 import type { EntityServerSpec } from '@/shared/dal/server/types'
 import type { Meeting } from '@/shared/db/schema'
 
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/shared/db'
 import {
   insertMeetingSchema,
   meetings,
@@ -10,9 +13,10 @@ import { OUTCOME_PIPELINE_MAP } from '@/shared/domains/pipelines/lib/outcome-pip
 import { addParticipant } from '@/shared/entities/meetings/dal/server/participants'
 import { MEETING } from '@/shared/entities/meetings/lib/constants'
 import { meetingVisibility } from '@/shared/entities/meetings/lib/visibility'
-import { notificationService } from '@/shared/services/notification.service'
+import { deleteMeetingEventJob } from '@/shared/services/providers/upstash/jobs/delete-meeting-event'
+import { notifyMeetingTimeChangedJob } from '@/shared/services/providers/upstash/jobs/notify-meeting-time-changed'
+import { syncMeetingToGcalJob } from '@/shared/services/providers/upstash/jobs/sync-meeting-to-gcal'
 import { ably } from '@/shared/services/providers/upstash/realtime'
-import { schedulingService } from '@/shared/services/scheduling.service'
 
 const updateMeetingSchema = insertMeetingSchema.partial()
 
@@ -48,17 +52,18 @@ export const meetingServerSpec = {
         return input
       },
       // Merged from lifecycle.ts onCreated + onDuplicated (identical behavior).
-      // Uses row.ownerId (not ctx.session.user.id) so the participant and the
-      // GCal push follow the meeting's actual owner — correct for both the
-      // authed UI path (row.ownerId === session.user.id by virtue of the
-      // before hook) and the SYSTEM_CONTEXT orchestrator path.
+      // Uses row.ownerId (not ctx.session.user.id) so the participant follows
+      // the meeting's actual owner — correct for both the authed UI path
+      // (row.ownerId === session.user.id by virtue of the before hook) and
+      // the SYSTEM_CONTEXT orchestrator path. The GCal push is enqueued as a
+      // QStash job — strict dispatch so a missed enqueue fails the mutation
+      // rather than silently dropping the event.
+      // see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
       async after(row: Meeting, _ctx) {
         await addParticipant(row.id, row.ownerId, 'owner')
 
         if (row.scheduledFor) {
-          void schedulingService
-            .pushToGCal(row.ownerId, 'meeting', row.id)
-            .catch(err => console.error(`[meetings.create] GCal push failed for ${row.id}:`, err))
+          await syncMeetingToGcalJob.dispatchOrThrow({ meetingId: row.id })
         }
       },
     },
@@ -73,30 +78,83 @@ export const meetingServerSpec = {
         }
         return data
       },
-      // Merged from lifecycle.ts onUpdated
+      // Merged from lifecycle.ts onUpdated.
+      // Reads row.ownerId (not ctx.session.user.id) for parity with create.after —
+      // SYSTEM_CONTEXT callers (e.g., inbound GCal sync, the new pipeline-stage
+      // transition path that uses buildUserContext) must not crash here.
+      // excludeUserId on the notification is optional — SYSTEM_CONTEXT means
+      // no "actor" to exclude (notify all participants).
+      //
+      // Side-effect taxonomy:
+      // - GCal sync + time-changed push → QStash jobs, dispatchOrThrow.
+      //   Critical work; silent loss is the bug class this refactor closed.
+      //   Parallelized via Promise.all to share the dispatch round-trip.
+      // - Ably publish → inline await. Ephemeral realtime fan-out; routing
+      //   through QStash would add 100-300ms of delay and defeat the point.
+      // see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
       async after(row: Meeting, ctx, meta) {
         const { previousRow, input: data } = meta
 
-        if ('scheduledFor' in data || 'meetingType' in data || 'agentNotes' in data) {
-          void schedulingService
-            .pushToGCal(ctx.session!.user.id, 'meeting', row.id)
-            .catch(err => console.error(`[meetings.update] GCal push failed for ${row.id}:`, err))
+        // GCal-affecting fields on a meeting:
+        // - scheduledFor → event start/end time
+        // - meetingType → event title prefix and color (Fresh/Rehash/Project)
+        // - agentNotes → event description body
+        // - projectId → event title prefix flips to "Project:" + color flips
+        const gcalFieldChanged = 'scheduledFor' in data
+          || 'meetingType' in data
+          || 'agentNotes' in data
+          || 'projectId' in data
+        const timeChanged = previousRow.scheduledFor !== row.scheduledFor
+
+        const dispatches: Promise<unknown>[] = []
+        if (gcalFieldChanged) {
+          dispatches.push(syncMeetingToGcalJob.dispatchOrThrow({ meetingId: row.id }))
+        }
+        if (timeChanged) {
+          dispatches.push(notifyMeetingTimeChangedJob.dispatchOrThrow({
+            meetingId: row.id,
+            oldScheduledFor: previousRow.scheduledFor,
+            newScheduledFor: row.scheduledFor,
+            excludeUserId: ctx.session?.user.id,
+          }))
+        }
+        if (dispatches.length > 0) {
+          await Promise.all(dispatches)
         }
 
-        if (previousRow.scheduledFor !== row.scheduledFor) {
-          void notificationService
-            .notifyMeetingScheduledTimeChanged({
-              meetingId: row.id,
-              oldScheduledFor: previousRow.scheduledFor,
-              newScheduledFor: row.scheduledFor,
-              excludeUserId: ctx.session!.user.id,
-            })
-            .catch(err => console.warn('[push] notifyMeetingScheduledTimeChanged failed:', err))
-        }
-
-        void ably.channels.get(`meeting:${row.id}`).publish('meeting.updated', {
+        await ably.channels.get(`meeting:${row.id}`).publish('meeting.updated', {
           fields: Object.keys(data),
         })
+      },
+    },
+    delete: {
+      // One-way GCal cleanup: deleting a meeting in-app deletes its event on
+      // the centralized info@ calendar. The reverse direction is intentionally
+      // NOT symmetric — cancelling an event in GCal clears the meeting's GCal
+      // linkage fields (`clearMeetingGCalFields` in performInboundSync) but
+      // leaves the meeting row intact, so an accidental GCal-side delete
+      // doesn't destroy app data.
+      //
+      // Captured in `before` because by `after` the row is gone and we can no
+      // longer read gcalEventId. The Google API call itself runs inside a
+      // QStash job — strict dispatch so a failed enqueue surfaces to the
+      // deleting agent rather than silently leaving an orphan event.
+      // Failure mode: if the QStash dispatch itself succeeds but the eventual
+      // job execution fails (auth, network, 5xx), QStash retries automatically;
+      // the handler is idempotent (provider swallows 404/410 from already-gone
+      // events). A future orphan-sweeper script can clean residue from cases
+      // where every QStash retry exhausts.
+      // see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
+      async before(id, _ctx) {
+        const [row] = await db
+          .select({ gcalEventId: meetings.gcalEventId })
+          .from(meetings)
+          .where(eq(meetings.id, String(id)))
+          .limit(1)
+        const gcalEventId = row?.gcalEventId
+        if (gcalEventId) {
+          await deleteMeetingEventJob.dispatchOrThrow({ gcalEventId })
+        }
       },
     },
   },
@@ -116,8 +174,12 @@ export const meetingServerSpec = {
       'gcalEtag',
       'gcalSyncedAt',
     ],
-    overrides: (_source, ctx) => ({
-      ownerId: ctx.session!.user.id,
+    // The create.before hook forces ownerId from session for authed callers
+    // and passes input through for SYSTEM_CONTEXT — so this override is a
+    // sane default that loses to before-hook on the authed path. Falls back
+    // to source.ownerId so a SYSTEM_CONTEXT duplicate doesn't crash.
+    overrides: (source, ctx) => ({
+      ownerId: ctx.session?.user.id ?? source.ownerId,
     }),
   },
 } satisfies EntityServerSpec<typeof meetings>

--- a/src/shared/services/notification.service.ts
+++ b/src/shared/services/notification.service.ts
@@ -155,7 +155,12 @@ function createNotificationService() {
       meetingId: string
       newScheduledFor: string | null
       oldScheduledFor: string | null
-      excludeUserId: string
+      /**
+       * Skip notifying this user. Optional so SYSTEM_CONTEXT callers
+       * (e.g., inbound GCal sync) can notify every participant — there
+       * is no "actor" to exclude in those flows.
+       */
+      excludeUserId?: string
     }) => {
       const [meeting] = await db
         .select({
@@ -178,7 +183,7 @@ function createNotificationService() {
         .from(meetingParticipants)
         .where(and(
           eq(meetingParticipants.meetingId, params.meetingId),
-          ne(meetingParticipants.userId, params.excludeUserId),
+          params.excludeUserId ? ne(meetingParticipants.userId, params.excludeUserId) : undefined,
         ))
 
       if (recipients.length === 0) {

--- a/src/shared/services/providers/upstash/jobs/delete-meeting-event.ts
+++ b/src/shared/services/providers/upstash/jobs/delete-meeting-event.ts
@@ -1,0 +1,21 @@
+import { schedulingService } from '@/shared/services/scheduling.service'
+
+import { createJob } from '../lib/create-job'
+
+/**
+ * Delete a GCal event by identifier on the centralized info@ calendar.
+ * Fired from `meetingServerSpec.hooks.delete.before` (the meeting row is
+ * gone by the time this runs — payload carries the event id captured
+ * pre-delete). Strict dispatch so a missed enqueue surfaces as a 500 on
+ * the deleting agent's screen rather than silently leaving an orphan
+ * event on the master calendar.
+ *
+ * Handler is idempotent: the provider swallows 404/410 (already-gone
+ * events). Safe under QStash retry.
+ */
+export const deleteMeetingEventJob = createJob(
+  'delete-meeting-event',
+  async (payload: { gcalEventId: string }) => {
+    await schedulingService.deleteMeetingEvent({ gcalEventId: payload.gcalEventId })
+  },
+)

--- a/src/shared/services/providers/upstash/jobs/notify-meeting-time-changed.ts
+++ b/src/shared/services/providers/upstash/jobs/notify-meeting-time-changed.ts
@@ -1,0 +1,27 @@
+import { notificationService } from '@/shared/services/notification.service'
+
+import { createJob } from '../lib/create-job'
+
+/**
+ * Send the "meeting time changed" push to every participant except the
+ * acting user. Fired from `meetingServerSpec.hooks.update.after` when
+ * `previousRow.scheduledFor !== row.scheduledFor`. Strict dispatch
+ * because a dropped notification means a participant turns up at the
+ * wrong time — actively misleading, not just absent.
+ *
+ * Handler is idempotent enough for QStash retry: web-push delivery is
+ * already best-effort at the platform layer, and two identical
+ * notifications inside the same retry window land as a single visible
+ * one on most clients.
+ */
+export const notifyMeetingTimeChangedJob = createJob(
+  'notify-meeting-time-changed',
+  async (payload: {
+    meetingId: string
+    oldScheduledFor: string | null
+    newScheduledFor: string | null
+    excludeUserId?: string
+  }) => {
+    await notificationService.notifyMeetingScheduledTimeChanged(payload)
+  },
+)

--- a/src/shared/services/providers/upstash/jobs/propagate-customer-change.ts
+++ b/src/shared/services/providers/upstash/jobs/propagate-customer-change.ts
@@ -1,0 +1,21 @@
+import { schedulingService } from '@/shared/services/scheduling.service'
+
+import { createJob } from '../lib/create-job'
+
+/**
+ * Re-sync every meeting of a single customer that already has a GCal
+ * event, so customer-derived fields embedded in the event payload (name,
+ * phone, email, address) reflect the latest DB row. Fired from
+ * `customerServerSpec.hooks.update.after` on every customer update —
+ * `propagateCustomerChange` short-circuits internally if the customer
+ * has no synced meetings, so unrelated customer edits are cheap.
+ *
+ * Handler is idempotent: each per-meeting push re-uses GCal etags for
+ * optimistic concurrency. Safe under QStash retry.
+ */
+export const propagateCustomerChangeJob = createJob(
+  'propagate-customer-change',
+  async (payload: { customerId: string }) => {
+    await schedulingService.propagateCustomerChange(payload.customerId)
+  },
+)

--- a/src/shared/services/providers/upstash/jobs/sync-calendars.ts
+++ b/src/shared/services/providers/upstash/jobs/sync-calendars.ts
@@ -2,6 +2,30 @@ import { getAccountsWithGCalEnabled } from '@/shared/entities/accounts/dal/serve
 import { schedulingService } from '@/shared/services/scheduling.service'
 import { createJob } from '../lib/create-job'
 
+/**
+ * Periodic refresh for every account that has a Google Calendar linked:
+ *  1. Pull inbound changes from GCal (catches events created/edited in
+ *     the GCal UI for any per-user activity calendar, AND on the system
+ *     owner's centralized meetings calendar).
+ *  2. Renew the webhook channel if it's within 24h of expiry. Google
+ *     channels cap at 7 days — without this renewal, inbound webhooks
+ *     stop firing and the app drifts out of sync silently.
+ *
+ * **Scheduling required** — this job has no automatic trigger today. It
+ * must be scheduled externally:
+ *   - QStash dashboard → recurring message to
+ *     `${BASE_URL}/api/qstash-jobs?job=sync-calendars` (recommended; the
+ *     existing route handler already verifies QStash signatures), OR
+ *   - Vercel Cron → `vercel.json` `crons` entry hitting a new cron-only
+ *     endpoint with `CRON_SECRET` auth (requires new env var + route).
+ *
+ * Recommended cadence: every 12-24h. The renewal-eligibility window is
+ * 24h before expiry, so any cadence ≤24h keeps channels evergreen.
+ *
+ * Until scheduled, super-admins can manually trigger renewal for the
+ * system owner via `scheduleRouter.sync.renewSystemOwnerChannel`, and
+ * observe channel health via `scheduleRouter.sync.systemOwnerHealth`.
+ */
 export const syncCalendarsJob = createJob(
   'sync-calendars',
   async (_payload: Record<string, never>) => {

--- a/src/shared/services/providers/upstash/jobs/sync-meeting-to-gcal.ts
+++ b/src/shared/services/providers/upstash/jobs/sync-meeting-to-gcal.ts
@@ -1,0 +1,21 @@
+import { schedulingService } from '@/shared/services/scheduling.service'
+
+import { createJob } from '../lib/create-job'
+
+/**
+ * Push (create or update) a meeting's GCal event on the centralized info@
+ * calendar. Fired from `meetingServerSpec.hooks.{create,update}.after` via
+ * `dispatchOrThrow` — a missed enqueue means the event drifts out of sync
+ * with the DB row, which is the bug class this entire pipeline was built
+ * to eliminate.
+ *
+ * Handler is idempotent: `schedulingService.syncMeeting` reads the current
+ * DB row, computes the payload from scratch, and uses GCal etags for
+ * optimistic concurrency. Safe to run twice on QStash retry.
+ */
+export const syncMeetingToGcalJob = createJob(
+  'sync-meeting-to-gcal',
+  async (payload: { meetingId: string }) => {
+    await schedulingService.syncMeeting(payload.meetingId)
+  },
+)

--- a/src/shared/services/providers/upstash/lib/create-job.ts
+++ b/src/shared/services/providers/upstash/lib/create-job.ts
@@ -9,23 +9,56 @@ type DispatchOptions<T> = Omit<
 >
 
 export function createJob<T>(key: string, handler: JobHandler<T>) {
+  // The QStash publish call — single source of truth for both dispatch variants.
+  // Returns void; throws on transport / auth / quota failures.
+  const publish = async (payload: T, options?: DispatchOptions<T>) =>
+    qstashClient.publishJSON({
+      ...options,
+      body: payload,
+      method: 'POST',
+      url: `${getPublicBaseUrl()}/api/qstash-jobs?job=${key}`,
+    })
+
   return {
     key,
     handler,
+    /**
+     * Best-effort dispatch. Logs and swallows QStash transport errors so the
+     * caller's mutation can still return successfully. Use for cosmetic /
+     * non-critical work (image optimization, view-tracking pings,
+     * "you were added" courtesy notifications) where a dropped enqueue is
+     * acceptable. Pair with explicit `void job.dispatch(...).catch(...)` at
+     * the call site to document intent.
+     *
+     * For critical work (data-integrity, calendar sync, time-changed pushes
+     * — anything where silent loss is a bug), use `dispatchOrThrow` instead.
+     * see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
+     */
     dispatch: async (payload: T, options?: DispatchOptions<T>) => {
       // eslint-disable-next-line no-console
       console.log('DISPATCHING JOB', key)
       try {
-        await qstashClient.publishJSON({
-          ...options,
-          body: payload,
-          method: 'POST',
-          url: `${getPublicBaseUrl()}/api/qstash-jobs?job=${key}`,
-        })
+        await publish(payload, options)
       }
       catch (error) {
         console.error('Something went wrong', error)
       }
+    },
+    /**
+     * Strict dispatch. Bubbles up QStash transport errors so the caller's
+     * mutation fails loudly if the enqueue can't be confirmed. Use for
+     * critical side effects (GCal sync, propagation, time-changed pushes)
+     * where a silent drop is worse than a visible 500 — the user can retry,
+     * but they cannot recover from work that quietly never happened.
+     *
+     * Handlers MUST be idempotent — QStash retries automatically on
+     * downstream failure.
+     * see docs/codebase-conventions/service-architecture.md#background-side-effects-via-qstash-jobs
+     */
+    dispatchOrThrow: async (payload: T, options?: DispatchOptions<T>) => {
+      // eslint-disable-next-line no-console
+      console.log('DISPATCHING JOB (strict)', key)
+      await publish(payload, options)
     },
   }
 }

--- a/src/shared/services/scheduling.service.ts
+++ b/src/shared/services/scheduling.service.ts
@@ -26,6 +26,7 @@ import {
   getAllMeetingsWithSchedule,
   getMeetingByGCalEventId,
   getMeetingForGCal,
+  getMeetingsForCustomerWithGCalEvent,
   updateMeetingGCalFields,
   updateMeetingScheduledFor,
 } from '@/shared/entities/meetings/dal/server/google-calendar'
@@ -112,7 +113,12 @@ async function performInboundSync(userId: string): Promise<void> {
       const winner = resolveConflict(linkedMeeting.updatedAt, gcalEvent.updated)
       if (winner === 'remote') {
         const local = gcalEventToLocal(gcalEvent)
-        await updateMeetingScheduledFor(linkedMeeting.id, local.scheduledFor)
+        // meetings.scheduled_for is NOT NULL — if the remote event lacks
+        // dateTime/date (rare, e.g. malformed event), preserve the existing
+        // local scheduledFor rather than blanking it.
+        if (local.scheduledFor) {
+          await updateMeetingScheduledFor(linkedMeeting.id, local.scheduledFor)
+        }
         await updateMeetingGCalFields(linkedMeeting.id, {
           gcalEtag: local.gcalEtag,
           gcalSyncedAt: new Date().toISOString(),
@@ -175,6 +181,80 @@ async function performInboundSync(userId: string): Promise<void> {
 
   if (eventList.nextSyncToken) {
     await updateAccountGCalFields(acct.id, { gcalSyncToken: eventList.nextSyncToken })
+  }
+}
+
+/**
+ * Resolve the system-owner's Google Calendar credentials + target calendar
+ * for any meeting-side outbound write. Returns null (with a console.error)
+ * when the system owner hasn't connected their calendar yet — callers
+ * treat that as a no-op rather than a thrown error so a missing setup
+ * doesn't break unrelated mutations.
+ */
+async function resolveSystemCalendarAuth(): Promise<{
+  auth: { accessToken: string, account: AccountRow }
+  calendarId: string
+} | null> {
+  const systemUserId = await getSystemOwnerId()
+  const auth = await getAccessTokenForUser(systemUserId)
+  if (!auth) {
+    console.error('[scheduling] No Google account linked for system owner')
+    return null
+  }
+  if (!auth.account.gcalCalendarId) {
+    console.error('[scheduling] No calendar ID for system owner')
+    return null
+  }
+  return { auth, calendarId: auth.account.gcalCalendarId }
+}
+
+/**
+ * Shared meeting-event push logic. Three branches:
+ * - payload null + existing event → delete (event becomes stale)
+ * - existing event → patch with etag (optimistic concurrency)
+ * - no event → create + persist new gcal_event_id + etag
+ *
+ * The "payload null" branch covers a legacy case (meeting without
+ * scheduledFor) that is unreachable today because the column is NOT NULL —
+ * kept for defense and so the `deleteMeetingEvent` exit on stale linkage
+ * can compose with this without a separate code path.
+ */
+async function pushMeetingEventToCalendar(
+  auth: { accessToken: string },
+  calendarId: string,
+  meetingId: string,
+  meeting: NonNullable<Awaited<ReturnType<typeof getMeetingForGCal>>>,
+): Promise<void> {
+  const payload = meetingToGCalEvent(meeting)
+
+  if (!payload) {
+    if (meeting.gcalEventId) {
+      await googleCalendarClient.deleteEvent(auth.accessToken, calendarId, meeting.gcalEventId)
+      await clearMeetingGCalFields(meetingId)
+    }
+    return
+  }
+
+  if (meeting.gcalEventId) {
+    const updated = await googleCalendarClient.updateEvent(
+      auth.accessToken,
+      calendarId,
+      meeting.gcalEventId,
+      payload,
+      meeting.gcalEtag ?? undefined,
+    )
+    await updateMeetingGCalFields(meetingId, {
+      gcalEtag: updated.etag,
+      gcalSyncedAt: new Date().toISOString(),
+    })
+  }
+  else {
+    const created = await googleCalendarClient.createEvent(auth.accessToken, calendarId, payload)
+    await updateMeetingGCalFields(meetingId, {
+      gcalEventId: created.id,
+      gcalEtag: created.etag,
+      gcalSyncedAt: new Date().toISOString(),
+    })
   }
 }
 
@@ -277,63 +357,90 @@ function createSchedulingService() {
       await clearAllActivityGCalFieldsForUser(userId)
     },
 
-    pushToGCal: async (userId: string, entityType: 'meeting' | 'activity', entityId: string): Promise<void> => {
-      if (entityType === 'meeting') {
-        // Meetings always push to the centralized info@ system calendar
-        const systemUserId = await getSystemOwnerId()
-        const auth = await getAccessTokenForUser(systemUserId)
-        if (!auth) {
-          console.error('[pushToGCal] No Google account linked for system owner')
-          return
-        }
-
-        const acct = auth.account
-        if (!acct.gcalCalendarId) {
-          console.error('[pushToGCal] No calendar ID for system owner')
-          return
-        }
-
-        const calendarId = acct.gcalCalendarId
-        const meeting = await getMeetingForGCal(entityId)
-        if (!meeting) {
-          return
-        }
-
-        const payload = meetingToGCalEvent(meeting)
-
-        if (!payload) {
-          if (meeting.gcalEventId) {
-            await googleCalendarClient.deleteEvent(auth.accessToken, calendarId, meeting.gcalEventId)
-            await clearMeetingGCalFields(entityId)
-          }
-          return
-        }
-
-        if (meeting.gcalEventId) {
-          const updated = await googleCalendarClient.updateEvent(
-            auth.accessToken,
-            calendarId,
-            meeting.gcalEventId,
-            payload,
-            meeting.gcalEtag ?? undefined,
-          )
-          await updateMeetingGCalFields(entityId, {
-            gcalEtag: updated.etag,
-            gcalSyncedAt: new Date().toISOString(),
-          })
-        }
-        else {
-          const created = await googleCalendarClient.createEvent(auth.accessToken, calendarId, payload)
-          await updateMeetingGCalFields(entityId, {
-            gcalEventId: created.id,
-            gcalEtag: created.etag,
-            gcalSyncedAt: new Date().toISOString(),
-          })
-        }
+    /**
+     * Sync a single meeting to the centralized info@ calendar.
+     * Creates the event if `gcal_event_id` is null, updates it otherwise.
+     * Caller passes meetingId only — the owner-of-the-calendar is always
+     * the system owner (info@), not the meeting's row.ownerId. No-ops if
+     * the system owner's Google account isn't linked yet.
+     */
+    syncMeeting: async (meetingId: string): Promise<void> => {
+      const ctx = await resolveSystemCalendarAuth()
+      if (!ctx) {
         return
       }
+      const meeting = await getMeetingForGCal(meetingId)
+      if (!meeting) {
+        return
+      }
+      await pushMeetingEventToCalendar(ctx.auth, ctx.calendarId, meetingId, meeting)
+    },
 
-      // Activities continue to use the per-user calendar
+    /**
+     * One-way delete of a GCal event when its meeting row is being deleted.
+     * Takes the event identifier directly (not a meetingId) because the
+     * row may no longer exist when this fires. Idempotent against 404s
+     * (event already gone in GCal) — Google returns 410 GONE for those;
+     * we swallow it.
+     */
+    deleteMeetingEvent: async (input: { gcalEventId: string }): Promise<void> => {
+      const ctx = await resolveSystemCalendarAuth()
+      if (!ctx) {
+        return
+      }
+      await googleCalendarClient
+        .deleteEvent(ctx.auth.accessToken, ctx.calendarId, input.gcalEventId)
+        .catch((err) => {
+          console.error(`[scheduling] deleteMeetingEvent failed for ${input.gcalEventId}:`, err)
+        })
+    },
+
+    /**
+     * Re-sync every meeting of a customer that already has a GCal event,
+     * so customer-derived fields embedded in the event (name, phone,
+     * email, address) reflect the latest customer row. Called from
+     * `customerServerSpec.hooks.update.after`. Per-meeting failures are
+     * logged and the loop continues — one Google API hiccup shouldn't
+     * abort the rest of the customer's projections.
+     *
+     * @migration(ably-realtime-kernel) — when the Ably kernel lands, this
+     * service (or the customer update hook calling it) should also publish
+     * a `customer:<id>` channel event so open meeting cards refresh their
+     * rendered customer fields without a full refetch.
+     */
+    propagateCustomerChange: async (customerId: string): Promise<void> => {
+      // Short-circuit if no synced events exist for this customer — avoids
+      // the system-calendar-auth resolve (and its console.error noise when
+      // the system owner isn't connected in dev) on every customer update.
+      const customerMeetings = await getMeetingsForCustomerWithGCalEvent(customerId)
+      if (customerMeetings.length === 0) {
+        return
+      }
+      const ctx = await resolveSystemCalendarAuth()
+      if (!ctx) {
+        return
+      }
+      for (const { id: meetingId } of customerMeetings) {
+        const meeting = await getMeetingForGCal(meetingId)
+        if (!meeting) {
+          continue
+        }
+        try {
+          await pushMeetingEventToCalendar(ctx.auth, ctx.calendarId, meetingId, meeting)
+        }
+        catch (err) {
+          console.error(`[scheduling] propagateCustomerChange: meeting ${meetingId} failed:`, err)
+        }
+      }
+    },
+
+    /**
+     * Sync a single activity to its OWNER's per-user calendar. Activities
+     * are not centralized like meetings — each agent's tasks/events live
+     * on their own connected calendar. No-ops if the user isn't connected
+     * or the activity type isn't in `gcalSyncableActivityTypes`.
+     */
+    syncActivity: async (userId: string, activityId: string): Promise<void> => {
       const auth = await getAccessTokenForUser(userId)
       if (!auth) {
         return
@@ -345,7 +452,7 @@ function createSchedulingService() {
       }
 
       const calendarId = acct.gcalCalendarId
-      const activity = await getActivityById(entityId)
+      const activity = await getActivityById(activityId)
       if (!activity) {
         return
       }
@@ -362,7 +469,7 @@ function createSchedulingService() {
       if (!payload) {
         if (activity.gcalEventId) {
           await googleCalendarClient.deleteEvent(auth.accessToken, calendarId, activity.gcalEventId)
-          await clearActivityGCalFields(entityId)
+          await clearActivityGCalFields(activityId)
         }
         return
       }
@@ -375,14 +482,14 @@ function createSchedulingService() {
           payload,
           activity.gcalEtag ?? undefined,
         )
-        await updateActivityGCalFields(entityId, {
+        await updateActivityGCalFields(activityId, {
           gcalEtag: updated.etag,
           gcalSyncedAt: new Date().toISOString(),
         })
       }
       else {
         const created = await googleCalendarClient.createEvent(auth.accessToken, calendarId, payload)
-        await updateActivityGCalFields(entityId, {
+        await updateActivityGCalFields(activityId, {
           gcalEventId: created.id,
           gcalEtag: created.etag,
           gcalSyncedAt: new Date().toISOString(),

--- a/src/trpc/routers/customers.router/business.router.ts
+++ b/src/trpc/routers/customers.router/business.router.ts
@@ -169,6 +169,18 @@ export function createCustomerBusinessRouter(entity: EntityToolkit<PgTable>) {
           throw new TRPCError({ code: 'TOO_MANY_REQUESTS', message: 'Too many submissions. Please try again later.' })
         }
 
+        // Server-side guard: meetings.scheduled_for is NOT NULL and the central-
+        // calendar push hook needs a real time. The intake form's Zod schema
+        // already enforces this for the customer_and_meeting mode; this guards
+        // direct API hits where someone POSTs without scheduledFor.
+        if (mode === 'customer_and_meeting' && !customerData.leadMetaJSON?.scheduledFor) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'A meeting must have a scheduled date.',
+          })
+        }
+        const scheduledFor = customerData.leadMetaJSON?.scheduledFor
+
         // Resolve session for meeting owner assignment (null for unauthenticated 3rd party)
         const session = (ctx as { session?: { user: { id: string } } }).session ?? null
 
@@ -248,7 +260,10 @@ export function createCustomerBusinessRouter(entity: EntityToolkit<PgTable>) {
             ownerId: ownerId!,
             customerId: customer.id,
             meetingType: 'Fresh',
-            scheduledFor: customerData.leadMetaJSON?.scheduledFor ?? undefined,
+            // Non-null-asserted: the BAD_REQUEST guard at the top of this
+            // mutation rejects customer_and_meeting submissions without
+            // scheduledFor, so we've already returned by now if it was missing.
+            scheduledFor: scheduledFor!,
           })
 
           if (!meetingResult.success) {

--- a/src/trpc/routers/meeting-flow.router.ts
+++ b/src/trpc/routers/meeting-flow.router.ts
@@ -35,9 +35,15 @@ export const meetingFlowRouter = createTRPCRouter({
         id: customerId,
         data: profiles,
       }))
-      void ably.channels.get(`meeting:${meetingId}`).publish('meeting.updated', {
-        fields: Object.keys(profiles),
-      })
+      // Inline await — ephemeral realtime fan-out is the explicit exception
+      // to background-side-effects-via-qstash-jobs (routing through QStash
+      // would defeat sub-100ms broadcast). Failure is logged, not surfaced —
+      // an unsubscribed channel or transient Ably 5xx shouldn't fail the
+      // profile-save mutation.
+      await ably.channels
+        .get(`meeting:${meetingId}`)
+        .publish('meeting.updated', { fields: Object.keys(profiles) })
+        .catch(err => console.warn('[meeting-flow] ably publish failed:', err))
       return updated
     }),
 

--- a/src/trpc/routers/meetings.router/participants.router.ts
+++ b/src/trpc/routers/meetings.router/participants.router.ts
@@ -214,10 +214,10 @@ export function createParticipantsRouter(entity: EntityToolkit<PgTable>) {
           }
         }
 
-        // Push updated attendee list to Google Calendar
-        const systemOwnerId = await getSystemOwnerId()
+        // Push updated attendee list to Google Calendar. The system-owner swap
+        // happens inside syncMeeting — caller doesn't need to pass owner.
         await schedulingService
-          .pushToGCal(systemOwnerId, 'meeting', meetingId)
+          .syncMeeting(meetingId)
           .catch(err => console.error(`[manageParticipants] GCal push failed for ${meetingId}:`, err))
 
         return { success: true }

--- a/src/trpc/routers/projects.router/business.router.ts
+++ b/src/trpc/routers/projects.router/business.router.ts
@@ -1,11 +1,13 @@
 import { TRPCError } from '@trpc/server'
 import { eq } from 'drizzle-orm'
+import { buildUserContext, dalVerifySuccess } from '@/shared/dal/server/lib/helpers'
 import { db } from '@/shared/db'
 import { customers } from '@/shared/db/schema/customers'
-import { meetings } from '@/shared/db/schema/meetings'
 import { projects } from '@/shared/db/schema/projects'
 import { proposals } from '@/shared/db/schema/proposals'
 import { x_projectScopes } from '@/shared/db/schema/x-project-scopes'
+import { meetingCrud } from '@/shared/entities/meetings/dal/server/crud'
+import { meetingServerSpec } from '@/shared/entities/meetings/lib/server-spec'
 import { createProjectFormSchema } from '@/shared/entities/projects/schemas'
 import { agentProcedure, createTRPCRouter } from '../../init'
 
@@ -60,11 +62,19 @@ export const businessRouter = createTRPCRouter({
         })
         .returning()
 
-      // 5. Link meeting to project and set outcome
-      await db
-        .update(meetings)
-        .set({ projectId: project.id, meetingOutcome: 'converted_to_project' })
-        .where(eq(meetings.id, input.meetingId))
+      // 5. Link meeting to project and set outcome — through meetingCrud so the
+      //    entity update hook fires (sync to GCal with the new project prefix
+      //    + color, broadcast Ably refresh). `projectId` is now in the GCal
+      //    trigger set in meetingServerSpec.hooks.update.after.
+      const meetingCtx = buildUserContext(
+        ctx.session.user.id,
+        ctx.session.user.role,
+        meetingServerSpec,
+      )
+      dalVerifySuccess(await meetingCrud.update(meetingCtx, {
+        id: input.meetingId,
+        data: { projectId: project.id, meetingOutcome: 'converted_to_project' },
+      }))
 
       // 6. Extract scope IDs from proposals' SOWs and link to project
       const scopeIds = new Set<string>()

--- a/src/trpc/routers/schedule.router/activities.router.ts
+++ b/src/trpc/routers/schedule.router/activities.router.ts
@@ -133,7 +133,7 @@ export const activitiesRouter = createTRPCRouter({
         && !!created.scheduledFor
       if (isSyncable) {
         await schedulingService
-          .pushToGCal(ctx.session.user.id, 'activity', created.id)
+          .syncActivity(ctx.session.user.id, created.id)
           .catch(() => {})
       }
 
@@ -182,7 +182,7 @@ export const activitiesRouter = createTRPCRouter({
       }
 
       await schedulingService
-        .pushToGCal(ctx.session.user.id, 'activity', updated.id)
+        .syncActivity(ctx.session.user.id, updated.id)
         .catch(() => {})
 
       return updated

--- a/src/trpc/routers/schedule.router/sync.router.ts
+++ b/src/trpc/routers/schedule.router/sync.router.ts
@@ -1,9 +1,11 @@
+import { TRPCError } from '@trpc/server'
 import { and, eq, isNotNull, isNull, or } from 'drizzle-orm'
 
 import { gcalSyncableActivityTypes } from '@/shared/constants/enums'
 import { db } from '@/shared/db'
 import { activities } from '@/shared/db/schema/activities'
 import { meetings } from '@/shared/db/schema/meetings'
+import { getGoogleAccountForUser } from '@/shared/entities/accounts/dal/server/google-calendar'
 import { getSystemOwnerId } from '@/shared/entities/users/dal/server/system'
 import { schedulingService } from '@/shared/services/scheduling.service'
 import { agentProcedure, createTRPCRouter } from '@/trpc/init'
@@ -35,7 +37,6 @@ export const syncRouter = createTRPCRouter({
   triggerSync: agentProcedure
     .mutation(async ({ ctx }) => {
       const userId = ctx.session.user.id
-      const systemOwnerId = await getSystemOwnerId()
 
       // 1. Push unsynced meetings (have scheduledFor but no gcalEventId)
       // All meetings live on the centralized info@ calendar regardless of owner.
@@ -49,9 +50,9 @@ export const syncRouter = createTRPCRouter({
 
       for (const m of unsyncedMeetings) {
         await schedulingService
-          .pushToGCal(systemOwnerId, 'meeting', m.id)
+          .syncMeeting(m.id)
           .catch((err) => {
-            console.error(`[triggerSync] pushToGCal meeting ${m.id} failed:`, err)
+            console.error(`[triggerSync] syncMeeting ${m.id} failed:`, err)
           })
       }
 
@@ -70,9 +71,9 @@ export const syncRouter = createTRPCRouter({
 
       for (const a of unsyncedActivities) {
         await schedulingService
-          .pushToGCal(userId, 'activity', a.id)
+          .syncActivity(userId, a.id)
           .catch((err) => {
-            console.error(`[triggerSync] pushToGCal activity ${a.id} failed:`, err)
+            console.error(`[triggerSync] syncActivity ${a.id} failed:`, err)
           })
       }
 
@@ -80,5 +81,70 @@ export const syncRouter = createTRPCRouter({
       await schedulingService.handleInboundSync(userId)
 
       return { synced: true }
+    }),
+
+  /**
+   * Diagnostic snapshot of the centralized info@ calendar's sync state.
+   * Surfaces the failure mode behind "inbound GCal edits stopped reaching
+   * the app" — typically a webhook channel that expired without renewal.
+   * Super-admin gated; safe to expose to operators only.
+   */
+  systemOwnerHealth: agentProcedure
+    .query(async ({ ctx }) => {
+      if (ctx.ability.cannot('manage', 'all')) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only super-admins can view system-owner sync health.',
+        })
+      }
+
+      const systemOwnerId = await getSystemOwnerId()
+      const acct = await getGoogleAccountForUser(systemOwnerId)
+
+      if (!acct) {
+        return {
+          connected: false,
+          calendarId: null,
+          channelId: null,
+          channelExpiresAt: null,
+          channelExpired: null,
+          hasSyncToken: false,
+          tokenRefreshAt: null,
+        }
+      }
+
+      const channelExpiry = acct.gcalChannelExpiry ? new Date(acct.gcalChannelExpiry) : null
+      const channelExpired = channelExpiry ? channelExpiry.getTime() < Date.now() : null
+
+      return {
+        connected: !!acct.gcalCalendarId,
+        calendarId: acct.gcalCalendarId,
+        channelId: acct.gcalChannelId,
+        channelExpiresAt: acct.gcalChannelExpiry,
+        channelExpired,
+        hasSyncToken: !!acct.gcalSyncToken,
+        tokenRefreshAt: acct.accessTokenExpiresAt,
+      }
+    }),
+
+  /**
+   * Manually re-arm the system owner's webhook channel. Calls
+   * renewChannelIfNeeded — which is a no-op if the channel still has >24h
+   * left, otherwise stops the old watch and registers a new one. Intended
+   * as a fallback for operators when the scheduled cron hasn't run or has
+   * been failing. Super-admin gated.
+   */
+  renewSystemOwnerChannel: agentProcedure
+    .mutation(async ({ ctx }) => {
+      if (ctx.ability.cannot('manage', 'all')) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Only super-admins can renew the system owner channel.',
+        })
+      }
+
+      const systemOwnerId = await getSystemOwnerId()
+      await schedulingService.renewChannelIfNeeded(systemOwnerId)
+      return { renewed: true }
     }),
 })


### PR DESCRIPTION
## Summary

Closes the silent-loss bug class behind sean@'s missing Google Calendar events for intake-created meetings and makes the customer ↔ meeting ↔ centralized-calendar sync end-to-end durable.

- **Root cause #1**: `customers.createFromIntake` used a raw `db.insert(meetings)` that bypassed the entity's `create.after` hook — no GCal push fired. Now routed through `meetingCrud.create` so every code path produces identical side effects.
- **Root cause #2**: `meetings.scheduled_for` was nullable, but the GCal push hook only fires when it's set. Now `NOT NULL` at the schema layer with a tRPC `BAD_REQUEST` guard on the intake form path.
- **Root cause #3**: customer name/address/phone/email changes never propagated to existing synced GCal events. New `customer.update.after` hook dispatches a `propagate-customer-change` job that re-pushes every meeting of the customer that already has a `gcal_event_id`.
- **Root cause #4**: meeting deletion left orphan GCal events. New `meeting.delete.before` captures `gcal_event_id` and dispatches a `delete-meeting-event` job.
- **Root cause #5**: `after()` from `next/server` is best-effort with no retries — wrong tool for any side effect we care about landing. Migrated to QStash jobs throughout; `after()` is now a documented anti-pattern. New convention rule `background-side-effects-via-qstash-jobs` codifies `dispatchOrThrow` (critical) vs `dispatch` (cosmetic).
- **Root cause #6**: webhook channels expired silently every 7 days, killing inbound (GCal → app) sync. Adds the `gcal:cron:setup` script that registers a 12h QStash schedule against the existing `sync-calendars` job, plus operator-facing `systemOwnerHealth` query and `renewSystemOwnerChannel` mutation as manual fallbacks.

## Commits

- `feat(gcal): infra for durable customer↔meeting↔calendar sync` — additive infra (schema NOT NULL, `dispatchOrThrow`, 4 new jobs, scheduling service split, cron setup script, observability tRPC procedures, convention doc).
- `refactor(gcal): migrate hooks + callers off after() and pushToGCal` — wire-up. All meeting writes through `meetingCrud`, all GCal side effects through QStash jobs.

## Schema change

`meetings.scheduled_for SET NOT NULL`. Verified zero NULL rows on prod before staging. To be applied with `pnpm db:push` (naked, no migration file).

## Test plan

- [ ] `pnpm tsc` — clean
- [ ] `pnpm lint` — clean (pre-existing warnings only, none in touched files)
- [ ] **Dev smoke completed** ✓ — customer field changes propagate to GCal event; two-way scheduledFor sync verified app ↔ GCal; bulk-seed on `Connect Calendar` populated existing meetings; cron tick exercised the renewal path.

## Post-merge deploy steps

1. `pnpm db:push` (prod) — applies the NOT NULL constraint.
2. `pnpm gcal:cron:setup -- --apply` (prod env) — registers the 12h renewal cron against the prod URL. The script's `assertReachableDestination` guard refuses if `NGROK_URL` leaks from `.env.local` into the prod invocation.
3. Smoke: create → edit → address-change → delete → inbound, against info@'s prod "Tri Pros Schedule" calendar.
4. 48h monitoring of QStash dashboard for the 4 new job keys + `sync-calendars`.

See [docs/plans/2026-06-01-gcal-sync-handoff.md](docs/plans/2026-06-01-gcal-sync-handoff.md) for the full deployment checklist + rollback plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)