### PR TITLE
fix(voip): close voipCampaignStatuses pgEnum reference gap on main

### DIFF
--- a/src/shared/constants/enums/voip.ts
+++ b/src/shared/constants/enums/voip.ts
@@ -1,10 +1,10 @@
-// Cross-source discriminator (used by voip_calls, voip_messages, voip_dids).
-// 'cloudtalk' rows are populated by voip-campaigns' webhook handler; 'in_house' rows by Twilio webhooks.
-export const voipSources = ['in_house', 'cloudtalk'] as const
-export type VoipSource = (typeof voipSources)[number]
+// ── voip-in-house (Twilio) ──────────────────────────────────────────────────
+// Phase 1 ships 4 enums total. See docs/plans/voip-in-house/phase-1-mvp.md
+// GRILL RESULTS (2026-05-30) for the reduction rationale (total separation
+// from voip-campaigns ⇒ no `source` discriminator, no CT-only states,
+// no warm-transfer infra, no DNC-source enum since DNC lives on customers).
 
-// Call lifecycle (in-house Twilio call). CloudTalk-originated rows use the same enum;
-// 'no_answer' and 'voicemail' are the CloudTalk-side terminals.
+// Call lifecycle (in-house Twilio call only).
 export const voipCallStatuses = [
   'queued',
   'initiated',
@@ -18,52 +18,10 @@ export const voipCallStatuses = [
 ] as const
 export type VoipCallStatus = (typeof voipCallStatuses)[number]
 
-// Disposition recorded post-call (agent picks via UI; CloudTalk populates via webhook for 'cloudtalk' source).
-export const voipCallDispositions = [
-  'booked_meeting',
-  'callback_scheduled',
-  'interested_not_now',
-  'not_interested',
-  'wrong_number',
-  'opt_out',
-  'voicemail_left',
-  'unreached',
-] as const
-export type VoipCallDisposition = (typeof voipCallDispositions)[number]
-
-// DID lifecycle. In-house DIDs are typically 'active' (low-volume; no warming cycle).
-// CloudTalk DIDs may use 'warming' / 'cooldown' / 'flagged' / 'retired' per voip-campaigns rotation policy.
-export const voipDidStatuses = ['active', 'warming', 'cooldown', 'flagged', 'retired'] as const
-export type VoipDidStatus = (typeof voipDidStatuses)[number]
-
-// DID role within the in-house pool. Transfer-target receives general inbound (warm-transfer use case removed
-// in the 2026-05-27 pivot; endpoint remains scaffolded). Agent-outbound DIDs are sticky per agent
-// (assigned_user_id set). Campaign-rotation is voip-campaigns territory.
-export const voipDidRoles = ['transfer_target', 'agent_outbound', 'campaign_rotation'] as const
-export type VoipDidRole = (typeof voipDidRoles)[number]
-
-// DNC source. Matches INTEGRATION-SEAM.md §5 exactly.
-export const voipDncSources = [
-  'twilio_stop', // inbound STOP/UNSUB to in-house Twilio DID
-  'cloudtalk_stop', // inbound STOP to a CloudTalk DID (CloudTalk auto-honors + posts webhook)
-  'voice_request', // customer asked to be removed on a live call
-  'manual_admin', // admin clicks "Add to DNC" in admin UI
-  'ftc', // FTC DNC list scrub (Phase 2+ cron)
-] as const
-export type VoipDncSource = (typeof voipDncSources)[number]
-
-// Agent availability for receiving warm transfers.
-export const voipUserAvailabilities = ['available', 'on_call', 'off_shift'] as const
-export type VoipUserAvailability = (typeof voipUserAvailabilities)[number]
-
-// Transfer mode for receiving warm transfers. 'mobile' (cellular) is Phase 3; Phase 1 ships 'desktop' only.
-// 'auto' resolves to desktop if browser softphone registered, else mobile (Phase 3 behavior).
-export const voipTransferModes = ['desktop', 'mobile', 'auto'] as const
-export type VoipTransferMode = (typeof voipTransferModes)[number]
-
-// Message direction.
-export const voipMessageDirections = ['outbound', 'inbound'] as const
-export type VoipMessageDirection = (typeof voipMessageDirections)[number]
+// Direction — used by both voip_calls and voip_messages.
+// Renamed from voipMessageDirections per 2026-05-30 grill.
+export const voipDirections = ['outbound', 'inbound'] as const
+export type VoipDirection = (typeof voipDirections)[number]
 
 // Message status. SMS only — no iMessage values (Sendblue dropped permanently).
 export const voipMessageStatuses = [
@@ -76,6 +34,24 @@ export const voipMessageStatuses = [
 ] as const
 export type VoipMessageStatus = (typeof voipMessageStatuses)[number]
 
-// Tokenized-link type. L-DOC is Phase 1; others land per use case.
-export const voipLinkTokenTypes = ['l_doc', 'l_pay', 'l_cal', 'l_esign'] as const
+// Tokenized-link type. Phase 1 ships only `l_doc`; others land per use case
+// (narrowed from 4 → 1 per 2026-05-30 grill — YAGNI).
+export const voipLinkTokenTypes = ['l_doc'] as const
 export type VoipLinkTokenType = (typeof voipLinkTokenTypes)[number]
+
+// ── voip-campaigns (CloudTalk) ──────────────────────────────────────────────
+// 8-tier pipeline status — 1:1 with CT tag set (see lib/types.ts cloudtalkTagNames).
+// 'not_enrolled' is local-only (no CT counterpart). Replaces customers.pipelineStage.
+// see docs/plans/voip-campaigns/EPIC.md decisions log 2026-05-28/29 (Q9.F lock)
+// see src/shared/services/providers/cloudtalk/webhooks/lifecycle-mapper.ts
+export const voipCampaignStatuses = [
+  'not_enrolled',
+  'lead',
+  'engaged',
+  'transferred',
+  'booked',
+  'do_not_call',
+  'exhausted',
+  'bad_number',
+] as const
+export type VoipCampaignStatus = (typeof voipCampaignStatuses)[number]

--- a/src/shared/db/schema/meta.ts
+++ b/src/shared/db/schema/meta.ts
@@ -15,18 +15,11 @@ import {
   proposalStatuses,
   userRoles,
   viewSources,
-  voipCallDispositions,
   voipCallStatuses,
   voipCampaignStatuses,
-  voipDidRoles,
-  voipDidStatuses,
-  voipDncSources,
+  voipDirections,
   voipLinkTokenTypes,
-  voipMessageDirections,
   voipMessageStatuses,
-  voipSources,
-  voipTransferModes,
-  voipUserAvailabilities,
 } from '@/shared/constants/enums'
 import {
   constructionTypes,
@@ -66,16 +59,10 @@ export const projectStatusEnum = pgEnum('project_status', projectStatuses)
 // LEADS
 export const leadTypeEnum = pgEnum('lead_type', leadTypes)
 
-// VOIP IN-HOUSE (Twilio — agent comms + DIDs + DNC)
-export const voipSourceEnum = pgEnum('voip_source', voipSources)
+// VOIP IN-HOUSE (Twilio — agent ↔ already-known-customer comms)
+// 4 enums per 2026-05-30 grill. See docs/plans/voip-in-house/phase-1-mvp.md GRILL RESULTS.
 export const voipCallStatusEnum = pgEnum('voip_call_status', voipCallStatuses)
-export const voipCallDispositionEnum = pgEnum('voip_call_disposition', voipCallDispositions)
-export const voipDidStatusEnum = pgEnum('voip_did_status', voipDidStatuses)
-export const voipDidRoleEnum = pgEnum('voip_did_role', voipDidRoles)
-export const voipDncSourceEnum = pgEnum('voip_dnc_source', voipDncSources)
-export const voipUserAvailabilityEnum = pgEnum('voip_user_availability', voipUserAvailabilities)
-export const voipTransferModeEnum = pgEnum('voip_transfer_mode', voipTransferModes)
-export const voipMessageDirectionEnum = pgEnum('voip_message_direction', voipMessageDirections)
+export const voipDirectionEnum = pgEnum('voip_direction', voipDirections)
 export const voipMessageStatusEnum = pgEnum('voip_message_status', voipMessageStatuses)
 export const voipLinkTokenTypeEnum = pgEnum('voip_link_token_type', voipLinkTokenTypes)
 


### PR DESCRIPTION
## Summary

`origin/main` currently fails `pnpm tsc` due to a forward-reference bug:
- `src/shared/db/schema/meta.ts` registers `voipCampaignStatusEnum` (line 83) referencing a `voipCampaignStatuses` array that was never added to `src/shared/constants/enums/voip.ts`.
- This blocks CI on every PR opened against `main`, including [#245](https://github.com/OlisDevSpot/tri-pros-website/pull/245) (GCal sync overhaul).

## Root cause

Two prior VoIP commits split the addition unevenly:
- `28e9b32e feat(voip): add voip enum const arrays + types` — added 11 in-house enums to `voip.ts`. No campaigns enum.
- `d5d973fe feat(voip): register voip in-house pgEnums in meta.ts` — added pgEnums for those 11 plus an extra `voipCampaignStatusEnum` referencing a forward array that never landed.

## Fix

Cherry-pick of `9eea5799` (already authored on local `main`, never pushed):

`refactor(voip): trim enums per 2026-05-30 separation grill (11 → 4)`

Touches exactly 2 files:
- `src/shared/constants/enums/voip.ts` — adds the missing `voipCampaignStatuses` array + `VoipCampaignStatus` type. Also trims 7 in-house enums that became obsolete after the 2026-05-30 total-separation grill (no shared tables between voip-in-house and voip-campaigns ⇒ no `source` discriminator, no warm-transfer infra, no DNC-source enum since DNC lives on `customers`). Renames `voipMessageDirections` → `voipDirections`. Narrows `voipLinkTokenTypes` from 4 → 1.
- `src/shared/db/schema/meta.ts` — drops the 7 corresponding pgEnums and the obsolete imports.

Verified before pushing: zero references on `origin/main` to any of the 7 dropped enums outside the two files this commit touches (only docs cross-reference, and those will be updated when `75745094` lands via the broader VoIP-in-house PR).

## Test plan

- [x] `pnpm tsc` — clean (was broken on `origin/main`)
- [ ] `pnpm lint` — verify on CI

## Unblocks

- [#245](https://github.com/OlisDevSpot/tri-pros-website/pull/245) — GCal sync overhaul (CI currently failing on the same pgEnum gap)
- Any other in-flight PR against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)